### PR TITLE
Add version compatibility check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,6 +600,7 @@ dependencies = [
  "tempfile",
  "toml",
  "url",
+ "version-compare",
  "walkdir",
 ]
 
@@ -1300,6 +1301,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version-compare"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,5 @@ serde = { version = "1.0.192", features = ["derive"] }
 tempfile = "3.8.1"
 toml = "0.8.8"
 url = { version = "2.5.0", features = ["serde"] }
+version-compare = "0.1.1"
 walkdir = "2.4.0"

--- a/src/options.rs
+++ b/src/options.rs
@@ -48,7 +48,14 @@ pub struct CodeOptions {
 
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone)]
+pub struct Meta {
+    pub version: Option<String>
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct KerblamTomlOptions {
+    pub meta: Option<Meta>,
     pub data: Option<DataOptions>,
     code: Option<CodeOptions>,
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -7,7 +7,7 @@ use std::{collections::HashMap, path::PathBuf};
 use anyhow::Result;
 use url::Url;
 
-use crate::utils::find_files;
+use crate::utils::{find_files, warn_kerblam_version};
 
 // TODO: Remove the #[allow(dead_code)] calls when we actually use the
 // options here.
@@ -49,7 +49,7 @@ pub struct CodeOptions {
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone)]
 pub struct Meta {
-    pub version: Option<String>
+    pub version: Option<String>,
 }
 
 #[allow(dead_code)]
@@ -65,6 +65,8 @@ pub fn parse_kerblam_toml(toml_file: impl AsRef<Path>) -> Result<KerblamTomlOpti
     log::debug!("Reading {:?} for TOML options...", toml_file);
     let toml_content = String::from_utf8(fs::read(toml_file)?)?;
     let config: KerblamTomlOptions = toml::from_str(toml_content.as_str())?;
+
+    warn_kerblam_version(&config);
 
     Ok(config)
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::FromStr;
 
-use version_compare::{Cmp, Version};
+use version_compare::Version;
 use walkdir;
 
 use crate::options::KerblamTomlOptions;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,11 +5,11 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::str::FromStr;
 
-use walkdir;
 use version_compare::{Cmp, Version};
+use walkdir;
 
-use crate::VERSION;
 use crate::options::KerblamTomlOptions;
+use crate::VERSION;
 
 /// Create a directory.
 ///
@@ -269,23 +269,25 @@ pub fn find_files(inspected_path: impl AsRef<Path>, filters: Option<Vec<PathBuf>
     }
 }
 
-pub fn warn_kerblam_version(&config: KerblamTomlOptions) -> () {
-    let version = config.meta.and_then(|x| x.version);
+pub fn warn_kerblam_version(config: &KerblamTomlOptions) -> () {
+    // TODO: is there a way to avoid this clone()? I feel like there should be
+    // but I'm not sure.
+    let version = config.clone().meta.and_then(|x| x.version);
     let current_ver = Version::from(VERSION);
 
     let version = match version {
         None => return (),
-        Some(ver) => ver
+        Some(ver) => String::from(ver),
     };
 
     let version = match Version::from(&version) {
         Some(x) => x,
-        None => return ()
+        None => return (),
     };
 
     let current_ver = match current_ver {
         Some(x) => x,
-        None => return ()
+        None => return (),
     };
 
     if version != current_ver {
@@ -293,5 +295,4 @@ pub fn warn_kerblam_version(&config: KerblamTomlOptions) -> () {
             "⚠️  TOML version ({version}) is different from this kerblam version ({current_ver})!",
         )
     };
-
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,6 +6,10 @@ use std::process::Command;
 use std::str::FromStr;
 
 use walkdir;
+use version_compare::{Cmp, Version};
+
+use crate::VERSION;
+use crate::options::KerblamTomlOptions;
 
 /// Create a directory.
 ///
@@ -263,4 +267,31 @@ pub fn find_files(inspected_path: impl AsRef<Path>, filters: Option<Vec<PathBuf>
             .map(|x| x.path().to_owned())
             .collect()
     }
+}
+
+pub fn warn_kerblam_version(&config: KerblamTomlOptions) -> () {
+    let version = config.meta.and_then(|x| x.version);
+    let current_ver = Version::from(VERSION);
+
+    let version = match version {
+        None => return (),
+        Some(ver) => ver
+    };
+
+    let version = match Version::from(&version) {
+        Some(x) => x,
+        None => return ()
+    };
+
+    let current_ver = match current_ver {
+        Some(x) => x,
+        None => return ()
+    };
+
+    if version != current_ver {
+        println!(
+            "⚠️  TOML version ({version}) is different from this kerblam version ({current_ver})!",
+        )
+    };
+
 }


### PR DESCRIPTION
This would fix #18.

The check is placed in the code to generate the `KerblamTomlOptions`, so it's executed only when the options are created (e.g. not when running `kerblam new`).