### PR TITLE
Show available pipes on failed run/package command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kerblam"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 repository = "https://github.com/MrHedmad/kerblam"
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -3,10 +3,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Stdio};
 
-use crate::commands::new::normalize_path;
 use crate::options::KerblamTomlOptions;
+use crate::utils::find_file_by_name;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use crossbeam_channel::{bounded, Receiver};
 use ctrlc;
 
@@ -65,7 +65,7 @@ where
 
 pub struct Executor {
     target: FileMover,
-    env: Option<FileMover>,
+    env: Option<PathBuf>,
     strategy: ExecutionStrategy,
     // executor_path
 }
@@ -150,14 +150,7 @@ impl Executor {
 
         // Move the executor file
         cleanup.push(self.target.copy()?);
-        let dockerfile_path = self
-            .env
-            .clone()
-            .unwrap()
-            .from
-            .as_os_str()
-            .to_string_lossy()
-            .to_string();
+        let dockerfile_path = self.env.clone().unwrap().to_str().unwrap().to_string();
 
         let builder = || {
             Command::new("docker")
@@ -204,53 +197,51 @@ impl Executor {
         Ok(String::from(env_name))
     }
 
-    pub fn create(project_path: impl AsRef<Path>, module_name: &str) -> Result<Self> {
-        let project_path = project_path.as_ref();
-        let makefile = project_path.join("src/pipes/".to_string() + module_name + ".makefile");
-        let shellfile = project_path.join("src/pipes/".to_string() + module_name + ".sh");
-        let dockerfile =
-            project_path.join("src/dockerfiles/".to_string() + module_name + ".dockerfile");
+    pub fn create(
+        root_path: impl AsRef<Path>,
+        executor: impl AsRef<Path>,
+        environment: Option<impl AsRef<Path>>,
+    ) -> Result<Self> {
+        let executor = executor.as_ref();
+        let root_path = root_path.as_ref().to_path_buf();
+        if !executor.exists() {
+            bail!("Executor file {executor:?} does not exist");
+        }
 
-        let target: PathBuf;
-        let strategy = if makefile.exists() & shellfile.exists() {
-            bail!(
-                "Found both a makefile and a shellfile for module {}. Aborting!",
-                module_name
-            );
-        } else if makefile.exists() {
-            target = makefile;
-            ExecutionStrategy::Make
-        } else if shellfile.exists() {
-            target = shellfile;
-            ExecutionStrategy::Shell
-        } else {
-            bail!(
-                "Could not find either a shellfile or a makefile named {}!",
-                module_name
-            );
+        let target_mover = FileMover {
+            from: executor.to_path_buf(),
+            to: root_path.join("executor"),
         };
 
-        if dockerfile.exists() {
-            Ok(Self {
-                target: FileMover {
-                    from: target,
-                    to: project_path.join("executor"),
-                },
-                env: Some(FileMover {
-                    from: dockerfile,
-                    to: project_path.join("Dockerfile"),
-                }),
-                strategy,
-            })
-        } else {
-            Ok(Self {
-                target: FileMover {
-                    from: target,
-                    to: project_path.join("executor"),
-                },
+        let strategy = match executor.extension() {
+            None => {
+                return Err(anyhow!("Cannot determine execution strategy"))
+                    .with_context(|| "Specified executor has no extension")
+            }
+            Some(x) => match x.to_str().unwrap() {
+                "makefile" => ExecutionStrategy::Make,
+                "sh" => ExecutionStrategy::Shell,
+                ext => {
+                    return Err(anyhow!("Cannot determine execution strategy"))
+                        .with_context(|| format!("Unrecognized extension '{ext}'."))
+                }
+            },
+        };
+
+        match environment {
+            None => Ok(Self {
+                target: target_mover,
                 env: None,
                 strategy,
-            })
+            }),
+            Some(x) => {
+                let x = x.as_ref();
+                Ok(Self {
+                    target: target_mover,
+                    env: Some(x.to_path_buf()),
+                    strategy,
+                })
+            }
         }
     }
 
@@ -413,31 +404,22 @@ pub fn kerblam_run_project(
     runtime_dir: &PathBuf,
     profile: Option<String>,
 ) -> Result<String> {
-    // Check if the paths that we need are present
-    let expected_paths: Vec<PathBuf> = vec!["./data/in", "./src/pipes", "./src/dockerfiles"]
-        .into_iter()
-        .map(|x| runtime_dir.join(x))
-        .collect();
-    let module_file = &mut runtime_dir.join("./src/pipes");
-    module_file.push(module_name.trim().trim_matches('/'));
+    let pipes = config.pipes_paths();
+    let envs = config.env_paths();
+    let executor_file = find_file_by_name(&module_name, &pipes);
+    let environment_file = find_file_by_name(&module_name, &envs);
 
-    if expected_paths
-        .into_iter()
-        .map(|path| {
-            if !path.exists() {
-                println!("🔥 Could not find {:?}", normalize_path(path.as_path()));
-                true // i.e "Please crash"
-            } else {
-                false // i.e "Nothing to see here"
-            }
-        })
-        .any(|x| x)
-    {
-        bail!("Could not find required files.")
-    };
+    if executor_file.is_none() {
+        // We cannot find this executor. Warn the user and stop.
+        bail!(
+            "Could not find specified runtime '{module_name}'\n{}",
+            config.pipes_names_msg()
+        )
+    }
 
     // Create an executor for later.
-    let executor: Executor = Executor::create(runtime_dir, module_name.as_str())?;
+    let executor: Executor =
+        Executor::create(runtime_dir, executor_file.unwrap(), environment_file)?;
 
     // From here on we should not crash. Therefore, we have to catch SIGINTs
     // as the come in.

--- a/src/options.rs
+++ b/src/options.rs
@@ -42,8 +42,8 @@ pub struct DataOptions {
 #[allow(dead_code)]
 #[derive(Debug, Deserialize, Clone)]
 pub struct CodeOptions {
-    env_dir: Option<PathBuf>,
-    pipes_dir: Option<PathBuf>,
+    pub env_dir: Option<PathBuf>,
+    pub pipes_dir: Option<PathBuf>,
 }
 
 #[allow(dead_code)]
@@ -57,7 +57,7 @@ pub struct Meta {
 pub struct KerblamTomlOptions {
     pub meta: Option<Meta>,
     pub data: Option<DataOptions>,
-    code: Option<CodeOptions>,
+    pub code: Option<CodeOptions>,
 }
 
 pub fn parse_kerblam_toml(toml_file: impl AsRef<Path>) -> Result<KerblamTomlOptions> {
@@ -253,5 +253,27 @@ impl KerblamTomlOptions {
             .into_iter()
             .filter(|x| !remote_files.iter().any(|y| x == &y.path))
             .collect()
+    }
+
+    /// Return all paths to pipes.
+    pub fn pipes_paths(&self) -> Vec<PathBuf> {
+        let pipes = self
+            .code
+            .clone()
+            .and_then(|x| x.pipes_dir)
+            .unwrap_or_else(|| current_dir().unwrap().join("src/pipes"));
+
+        find_files(pipes, None)
+    }
+
+    /// Return all paths to environments.
+    pub fn env_paths(&self) -> Vec<PathBuf> {
+        let env = self
+            .code
+            .clone()
+            .and_then(|x| x.env_dir)
+            .unwrap_or_else(|| current_dir().unwrap().join("src/dockerfiles"));
+
+        find_files(env, None)
     }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -93,21 +93,9 @@ impl Into<Url> for RemoteFile {
 // quick and dirty to get the job done.
 
 impl KerblamTomlOptions {
-    /// Return the path to the root data directory, e.g. "./data"
-    fn root_data_dir(&self) -> PathBuf {
-        let here = &current_dir().unwrap();
-
-        self.data
-            .clone()
-            .and_then(|x| x.paths)
-            .and_then(|x| x.input.into())
-            .or_else(|| Some(here.join("data")))
-            .unwrap()
-    }
-
     /// Return objects representing remote files specified in the config
     pub fn remote_files(&self) -> Vec<RemoteFile> {
-        let root_data_dir = self.root_data_dir().join("in");
+        let root_data_dir = self.input_data_dir().join("in");
         log::debug!("Remote file save dir is {root_data_dir:?}");
 
         self.data

--- a/src/options.rs
+++ b/src/options.rs
@@ -276,4 +276,30 @@ impl KerblamTomlOptions {
 
         find_files(env, None)
     }
+
+    /// Return a message with available executor names
+    pub fn pipes_names_msg(&self) -> String {
+        let pipes = self.pipes_paths();
+        let envs = self.env_paths();
+        let pipes_names: Vec<String> = pipes
+            .into_iter()
+            .map(|x| x.file_stem().unwrap().to_string_lossy().to_string())
+            .collect();
+        let envs_names: Vec<String> = envs
+            .into_iter()
+            .map(|x| x.file_stem().unwrap().to_string_lossy().to_string())
+            .collect();
+
+        let mut lines: Vec<String> = vec!["Available pipes:".to_string()];
+
+        for pipe in pipes_names {
+            if envs_names.iter().any(|x| *x == pipe) {
+                lines.push(format!("    {pipe} 🐋"));
+            } else {
+                lines.push(format!("    {pipe}"));
+            }
+        }
+
+        lines.join("\n")
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -296,3 +296,17 @@ pub fn warn_kerblam_version(config: &KerblamTomlOptions) -> () {
         )
     };
 }
+
+pub fn find_file_by_name<'a>(name: &str, possibilities: &'a Vec<PathBuf>) -> Option<&'a PathBuf> {
+    for file in possibilities {
+        let stem = file.file_stem();
+        if stem.is_none() {
+            continue;
+        };
+        let stem = stem.unwrap().to_str().unwrap();
+        if stem == name {
+            return Some(file);
+        }
+    }
+    None
+}


### PR DESCRIPTION
This fixes #12. The `anyhow` error has the info:

```
Error: Could not find specified runtime 'test4'
Available pipes:
    test 🐋
    test3
    test2
```
The :whale2: icon signifies a pipe with a dockerfile.

The implementation is a bit clunky. Perhaps we should fuse the logic of finding the paths into a list of objects (e.g. `Pipe`) with both the path to the pipe and the path to the docker (if any).