### PR TITLE
Fix wrong remote data files path

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -96,7 +96,7 @@ impl Into<Url> for RemoteFile {
 impl KerblamTomlOptions {
     /// Return objects representing remote files specified in the config
     pub fn remote_files(&self) -> Vec<RemoteFile> {
-        let root_data_dir = self.input_data_dir().join("in");
+        let root_data_dir = self.input_data_dir();
         log::debug!("Remote file save dir is {root_data_dir:?}");
 
         self.data


### PR DESCRIPTION
The remote data files were being saved in `/data/in/in` instead of the correct location `/data/in/`. I suspect that the update to the paths being in the options added this in, and it slipped through.

Now the paths are correct.


<!--
Hello! Thanks for making a pull request. I'm just a comment that will not
be included in the final pull request reminding you to:
- Give the PR a nice title. It will be used in the changelog.
- Specify if you are fixing a specific issue in the text, for example:
   > This fixes #1234.
- Before merging, keep in mind the TODOs below.

Thanks for opening a PR! I appreciate it. You can delete this comment,
if you'd like!
-->

## TODO
Before merging, tick all of these boxes:
- [X] `cargo check` passes without errors or warnings.
- [X] @all-contributors is made aware of this PR.
