### PR TITLE
Package libssl into Kerblam!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,6 +607,8 @@ dependencies = [
  "filetime",
  "indicatif",
  "log",
+ "openssl",
+ "openssl-probe",
  "rand",
  "reqwest",
  "serde",
@@ -766,6 +768,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "300.1.6+3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439fac53e092cd7442a3660c85dde4643ab3b5bd39040912388dcdabf6b88085"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,6 +784,7 @@ checksum = "3812c071ba60da8b5677cc12bcb1d42989a65553772897a7e0355545a819838f"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,22 +14,24 @@ inherits = "release"
 lto = "thin"
 
 [dependencies]
-anyhow = "1.0.75"
-clap = { version = "4.4.8", features = ["derive"] }
-crossbeam-channel = "0.5.8"
-ctrlc = "3.4.1"
-env_logger = "0.10.1"
-filetime = "0.2.23"
-indicatif = "0.17.7"
-log = "0.4.20"
-rand = "0.8.5"
-reqwest = { version = "0.11.22", features = ["blocking"] }
-serde = { version = "1.0.192", features = ["derive"] }
-tempfile = "3.8.1"
-toml = "0.8.8"
-url = { version = "2.5.0", features = ["serde"] }
-version-compare = "0.1.1"
-walkdir = "2.4.0"
+anyhow = "^1.0"
+clap = { version = "^4.4", features = ["derive"] }
+crossbeam-channel = "^0.5"
+ctrlc = "^3.4"
+env_logger = "^0.10"
+filetime = "^0.2"
+indicatif = "^0.17"
+log = "^0.4"
+rand = "^0.8"
+reqwest = { version = "^0.11", features = ["blocking"] }
+openssl = { version = "^0.10", features = ["vendored"]}
+openssl-probe = "^0.1"
+serde = { version = "^1.0", features = ["derive"] }
+tempfile = "^3.8"
+toml = "^0.8"
+url = { version = "^2.5", features = ["serde"] }
+version-compare = "^0.1"
+walkdir = "^2.4"
 
 # Config for 'cargo dist'
 [workspace.metadata.dist]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use clap::{Parser, Subcommand};
 
 use anyhow::*;
+use openssl_probe::init_ssl_cert_env_vars;
 use options::parse_kerblam_toml;
 use std::{env::current_dir, path::PathBuf};
 
@@ -89,6 +90,8 @@ fn main() -> anyhow::Result<()> {
     // an Err, also calling `eprintln!(error)` for you.
     // So, we can just return the `StopError` when we get them.
     env_logger::init();
+    init_ssl_cert_env_vars();
+
     let here = &current_dir().unwrap();
     let args = Cli::parse();
 


### PR DESCRIPTION
<!--
Hello! Thanks for making a pull request. I'm just a comment that will not
be included in the final pull request reminding you to:
- Give the PR a nice title. It will be used in the changelog.
- Specify if you are fixing a specific issue in the text, for example:
   > This fixes #1234.
- Before merging, keep in mind the TODOs below.

Thanks for opening a PR! I appreciate it. You can delete this comment,
if you'd like!
-->

This is a tentative patch to fix #42. The libssl1.1 requirement is honestly out of nowhere (the build system?) since the `openssl` crate should link with whatever version is available.
The possible fixes are:
- Compile on the host system (with `cargo install --git ...`)
	- Pros: always works;
	- Cons: You need `cargo` and you need to wait for kerblam! to compile.
- Link with the proper version of `libssl` in our build systems;
	- Pros: It it as it should be, no extra work needed;
	- Cons: I have no idea what is making `rustc` link to the wrong lib;
- Package the `libssl` and the code to fetch the certificates in the host system (which would normally be done by the locally present, dynamically linked `libssl`) into kerblam! itself.
	- Pros: Easy to do and (probably) fixes the issue. Might help with having kerblam! run inside random docker containers (with unknown `libssl` versions).
	- Cons: Makes the build time longer (~+20%) and the executable larger (~2x, to 11Mb), which is undesirable.

## TODO
Before merging, tick all of these boxes:
- [X] `cargo check` passes without errors or warnings.
- [X] @all-contributors is made aware of this PR.
