### PR TITLE
Add podman support

### DIFF
--- a/src/commands/package.rs
+++ b/src/commands/package.rs
@@ -43,7 +43,8 @@ pub fn package_pipe(config: KerblamTomlOptions, pipe: Pipe, package_name: &str) 
 
     log::debug!("Building initial context...");
     let sigint_rec = setup_ctrlc_hook().expect("Failed to setup SIGINT hook!");
-    let base_container = executor.build_env(sigint_rec)?;
+    let backend: String = config.execution.backend.clone().into();
+    let base_container = executor.build_env(sigint_rec, &backend)?;
     log::debug!("Base container name: {base_container:?}");
 
     // We now start from this new docker and add our own layers, copying the
@@ -98,7 +99,7 @@ pub fn package_pipe(config: KerblamTomlOptions, pipe: Pipe, package_name: &str) 
 
     log::debug!("Packaging...");
     // Build this new container and tag it...
-    let res = Command::new("docker")
+    let res = Command::new(&backend)
         .args([
             "build",
             "--no-cache",

--- a/src/options.rs
+++ b/src/options.rs
@@ -62,6 +62,37 @@ pub struct KerblamTomlOptions {
     pub meta: Option<Meta>,
     pub data: Option<DataOptions>,
     pub code: Option<CodeOptions>,
+    #[serde(default)]
+    pub execution: ExecutionOptions,
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct ExecutionOptions {
+    #[serde(default)]
+    pub backend: ContainerBackend,
+}
+
+#[derive(Deserialize, Debug, Clone)]
+#[serde(rename_all = "lowercase")]
+pub enum ContainerBackend {
+    Docker,
+    Podman,
+}
+
+impl Default for ContainerBackend {
+    fn default() -> Self {
+        Self::Docker
+    }
+}
+
+impl Into<String> for ContainerBackend {
+    fn into(self) -> String {
+        match self {
+            Self::Docker => "docker".into(),
+            Self::Podman => "podman".into(),
+        }
+    }
 }
 
 pub fn parse_kerblam_toml(toml_file: impl AsRef<Path>) -> Result<KerblamTomlOptions> {


### PR DESCRIPTION
<!--
Hello! Thanks for making a pull request. I'm just a comment that will not
be included in the final pull request reminding you to:
- Give the PR a nice title. It will be used in the changelog.
- Specify if you are fixing a specific issue in the text, for example:
   > This fixes #1234.
- Before merging, keep in mind the TODOs below.

Thanks for opening a PR! I appreciate it. You can delete this comment,
if you'd like!
-->
By editing the new field in `kerblam.toml` one can swap the `docker` daemon with `podman`:
```toml
[execution]
backend = "podman" # or "docker", the default
```
Other backend strings are rejected by `serde` upon reading the toml. Since `podman` is essentially identical to `docker`, the change was just to swap where we use `docker` to using `podman`.

## TODO
Before merging, tick all of these boxes:
- [X] `cargo check` passes without errors or warnings.
- [X] @all-contributors is made aware of this PR.
