### PR TITLE
Overhaul containerized execution

### DIFF
--- a/src/commands/package.rs
+++ b/src/commands/package.rs
@@ -84,14 +84,14 @@ pub fn package_pipe(config: KerblamTomlOptions, pipe: Pipe, package_name: &str) 
     log::debug!("Writing wrapper dockerfile.");
 
     // Write the dockerfile
+    let workdir = config.execution.workdir.clone();
+    let workdir = workdir.to_string_lossy();
     let content = match executor.strategy() {
         ExecutionStrategy::Make => format!(
-            "FROM {}\nCOPY . .\nENTRYPOINT [\"bash\", \"-c\", \"./kerblam data fetch && make .\"]",
-            base_container
+            "FROM {base_container}\nCOPY . .\nENTRYPOINT [\"bash\", \"-c\", \"{workdir}/kerblam data fetch && make {workdir}\"]"
         ),
         ExecutionStrategy::Shell => format!(
-            "FROM {}\nCOPY . .\nENTRYPOINT [\"bash\", \"-c\", \"./kerblam data fetch && bash executor\"]",
-            base_container
+            "FROM {base_container}\nCOPY . .\nENTRYPOINT [\"bash\", \"-c\", \"{workdir}/kerblam data fetch && bash {workdir}/executor\"]"
         ),
     };
     let mut new_dockerfile = File::create(temp_build_dir.path().join("Dockerfile"))?;

--- a/src/commands/package.rs
+++ b/src/commands/package.rs
@@ -88,12 +88,13 @@ pub fn package_pipe(config: KerblamTomlOptions, pipe: Pipe, package_name: &str) 
     let workdir = workdir.to_string_lossy();
     let content = match executor.strategy() {
         ExecutionStrategy::Make => format!(
-            "FROM {base_container}\nCOPY . .\nENTRYPOINT [\"bash\", \"-c\", \"{workdir}/kerblam data fetch && make {workdir}\"]"
+            "FROM {base_container}\nCOPY . .\nENTRYPOINT [\"bash\", \"-c\", \"{workdir}/kerblam data fetch && make -C {workdir} -f {workdir}/executor\"]"
         ),
         ExecutionStrategy::Shell => format!(
             "FROM {base_container}\nCOPY . .\nENTRYPOINT [\"bash\", \"-c\", \"{workdir}/kerblam data fetch && bash {workdir}/executor\"]"
         ),
     };
+    log::debug!("Execution string: {content}");
     let new_container_file_path = temp_build_dir.path().join("Containerfile");
     let mut new_container_file = File::create(&new_container_file_path)?;
     new_container_file.write_all(content.as_bytes())?;

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,3 +1,4 @@
+use core::panic;
 use log;
 use std::collections::HashMap;
 use std::env::current_dir;
@@ -5,6 +6,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, ExitStatus, Stdio};
 
+use crate::commands::new::normalize_path;
 use crate::options::KerblamTomlOptions;
 use crate::options::Pipe;
 
@@ -98,13 +100,18 @@ fn generate_bind_mount_strings(config: &KerblamTomlOptions) -> Vec<String> {
         config.intermediate_data_dir(),
     ];
 
+    let host_workdir = config.execution.workdir.clone();
+
     for dir in dirs {
         // the folder here, in the local file system
         let local = dir.to_string_lossy().to_string();
         // the folder in the docker host
         let host = dir.strip_prefix(root.clone()).unwrap().to_string_lossy();
+        let host = host_workdir.join(format!("./{}", host));
+        let host = normalize_path(host.as_ref());
+        let host = host.to_string_lossy();
 
-        result.push(format!("{}:/{}", local, host))
+        result.push(format!("{}:{}", local, host))
     }
 
     result

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -136,6 +136,7 @@ impl Executor {
         let mut cleanup: Vec<PathBuf> = vec![];
 
         let command_args = if self.env.is_some() {
+            // This is a containerized run
             let backend: String = config.execution.backend.clone().into();
             let runtime_name = self.build_env(signal_receiver.clone(), &backend)?;
             let mut partial: Vec<String> = stringify![vec![&backend, "run", "-it"]];

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ enum Command {
     Package {
         /// The name of the pipe to package
         pipe: Option<String>,
-        /// The label of the exported docker image
+        /// The label of the exported container image
         #[arg(long)]
         name: Option<String>,
     },

--- a/src/options.rs
+++ b/src/options.rs
@@ -234,7 +234,7 @@ impl Pipe {
 
 impl Display for Pipe {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let docker_prefix = if self.env_path.is_none() { "" } else { "🐋 " };
+        let container_prefix = if self.env_path.is_none() { "" } else { "🐋 " };
         let desc_prefix = if self
             .description()
             .expect("Could not parse description file")
@@ -245,7 +245,7 @@ impl Display for Pipe {
             "📜 "
         };
 
-        let prefix = [docker_prefix, desc_prefix].concat();
+        let prefix = [container_prefix, desc_prefix].concat();
 
         let desc = self
             .description()

--- a/src/options.rs
+++ b/src/options.rs
@@ -71,6 +71,8 @@ pub struct KerblamTomlOptions {
 pub struct ExecutionOptions {
     #[serde(default)]
     pub backend: ContainerBackend,
+    #[serde(default = "_default_container_workdir")]
+    pub workdir: PathBuf,
 }
 
 #[derive(Deserialize, Debug, Clone)]
@@ -93,6 +95,11 @@ impl Into<String> for ContainerBackend {
             Self::Podman => "podman".into(),
         }
     }
+}
+
+// This exists only to circumvent Serde's weird #[default] behaviour
+fn _default_container_workdir() -> PathBuf {
+    PathBuf::from("/")
 }
 
 pub fn parse_kerblam_toml(toml_file: impl AsRef<Path>) -> Result<KerblamTomlOptions> {


### PR DESCRIPTION
<!--
Hello! Thanks for making a pull request. I'm just a comment that will not
be included in the final pull request reminding you to:
- Give the PR a nice title. It will be used in the changelog.
- Specify if you are fixing a specific issue in the text, for example:
   > This fixes #1234.
- Before merging, keep in mind the TODOs below.

Thanks for opening a PR! I appreciate it. You can delete this comment,
if you'd like!
-->

This PR adds the following features:
- Add the `execution > workdir` option to select the workdir inside the container where the pipeline is saved (e.g. to follow the `WORKDIR ...` directives).
- Have kerblam! override the `--entrypoint` of the containers to correctly run pipelines. This means that the user does not have to set the `ENTRYPOINT` or the `CMD` themselves in the dockerfiles.

## TODO
Before merging, tick all of these boxes:
- [X] `cargo check` passes without errors or warnings.
- [X] @all-contributors is made aware of this PR.
