### PR TITLE
Add Tests to Kerblam!

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,4 +14,7 @@ if you'd like!
 ## TODO
 Before merging, tick all of these boxes:
 - [ ] `cargo check` passes without errors or warnings.
+- [ ] `cargo test` passes without errors or warnings.
+- [ ] Documentation is updated that reflect these changes.
+  - [ ] This PR changes nothing that is reflected in docs.
 - [ ] @all-contributors is made aware of this PR.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.8.1/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.9.0/cargo-dist-installer.sh | sh"
       # sure would be cool if github gave us proper conditionals...
       # so here's a doubly-nested ternary-via-truthiness to try to provide the best possible
       # functionality based on whether this is a pull_request, and whether it's from a fork.
@@ -70,15 +70,15 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > dist-manifest.json
+          cargo dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
           echo "cargo dist ran successfully"
-          cat dist-manifest.json
-          echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
+          cat plan-dist-manifest.json
+          echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: artifacts
-          path: dist-manifest.json
+          name: artifacts-plan-dist-manifest
+          path: plan-dist-manifest.json
 
   # Build and packages all the platform-specific things
   build-local-artifacts:
@@ -113,10 +113,11 @@ jobs:
         run: ${{ matrix.install_dist }}
       # Get the dist-manifest
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          pattern: artifacts-*
           path: target/distrib/
+          merge-multiple: true
       - name: Install dependencies
         run: |
           ${{ matrix.packages_install }}
@@ -139,9 +140,9 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
             ${{ steps.cargo-dist.outputs.paths }}
             ${{ env.BUILD_MANIFEST_NAME }}
@@ -160,13 +161,14 @@ jobs:
         with:
           submodules: recursive
       - name: Install cargo-dist
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.8.1/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.9.0/cargo-dist-installer.sh | sh"
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          pattern: artifacts-*
           path: target/distrib/
+          merge-multiple: true
       - id: cargo-dist
         shell: bash
         run: |
@@ -180,9 +182,9 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          name: artifacts-build-global
           path: |
             ${{ steps.cargo-dist.outputs.paths }}
             ${{ env.BUILD_MANIFEST_NAME }}
@@ -204,13 +206,14 @@ jobs:
         with:
           submodules: recursive
       - name: Install cargo-dist
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.8.1/cargo-dist-installer.sh | sh"
+        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.9.0/cargo-dist-installer.sh | sh"
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          pattern: artifacts-*
           path: target/distrib/
+          merge-multiple: true
       # This is a harmless no-op for Github Releases, hosting for that happens in "announce"
       - id: host
         shell: bash
@@ -220,9 +223,10 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: artifacts
+          # Overwrite the previous copy
+          name: artifacts-dist-manifest
           path: dist-manifest.json
 
   # Create a Github Release while uploading all files to it
@@ -242,10 +246,11 @@ jobs:
         with:
           submodules: recursive
       - name: "Download Github Artifacts"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: artifacts
+          pattern: artifacts-*
           path: artifacts
+          merge-multiple: true
       - name: Cleanup
         run: |
           # Remove the granular manifests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chwd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd4a924c3a2029ba42e3306049602fd4708717418b01738b1605459cefc3002e"
+
+[[package]]
 name = "clap"
 version = "4.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -683,6 +689,7 @@ name = "kerblam"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "chwd",
  "clap",
  "crossbeam-channel",
  "ctrlc",
@@ -691,7 +698,9 @@ dependencies = [
  "indicatif",
  "log",
  "reqwest",
+ "rusty-fork",
  "serde",
+ "similar",
  "tempfile",
  "termimad",
  "toml",
@@ -898,6 +907,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,6 +1065,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1188,12 @@ checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "similar"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32fea41aca09ee824cc9724996433064c89f7777e60762749a4170a14abbfa21"
 
 [[package]]
 name = "slab"
@@ -1488,6 +1521,15 @@ name = "version-compare"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,14 @@ exclude = [
     "docs/", ".gitignore", ".github", ".all-contributorsrc",
     ".pre-commit-config.yaml", "trun"
 ]
+autotests = false
 
 [badges]
 maintenance = {status = "actively-developed"}
+
+[[test]]
+name = "integration"
+path = "tests/test.rs"
 
 [profile.release]
 strip = true # Strip symbols from binary to make it smaller
@@ -57,3 +62,8 @@ installers = ["shell"]
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"]
 # Publish jobs to run in CI
 pr-run-mode = "plan"
+
+[dev-dependencies]
+chwd = "0.2.0"
+rusty-fork = "0.3.0"
+similar = "2.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ walkdir = "^2.4"
 # Config for 'cargo dist'
 [workspace.metadata.dist]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.8.1"
+cargo-dist-version = "0.9.0"
 # CI backends to support
 ci = ["github"]
 # The installers to generate for each app

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -227,7 +227,16 @@ pub fn kerblam_run_project(
     // Return either an error or OK, if the pipeline finished appropriately
     // or crashed and burned.
     if runtime_result.is_ok() {
-        Ok(String::from("Done!"))
+        match runtime_result.unwrap() {
+            Some(res) => {
+                if res.success() {
+                    Ok("Done!".into())
+                } else {
+                    Err(anyhow!("Process exited with error."))
+                }
+            }
+            None => Err(anyhow!("Process killed.")),
+        }
     } else {
         Err(anyhow!("Process exited."))
     }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -385,15 +385,6 @@ impl FileMover {
     /// Invert this object, creating a new one with swapped from/to fields.
     ///
     /// This function destroys this original object.
-    ///
-    /// ```rust
-    /// let original = FileMover {
-    ///     from : PathBuf::from("/from.txt"),
-    ///     to: PathBuf::from("/to.txt")
-    /// };
-    ///
-    /// assert_eq(original, original.clone().invert().invert());
-    /// ```
     pub fn invert(self) -> Self {
         Self {
             from: self.to,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@ use clap::{Parser, Subcommand};
 
 use anyhow::*;
 use options::parse_kerblam_toml;
-use std::env::{set_current_dir, Args};
+use std::env::set_current_dir;
+use std::ffi::OsString;
 use std::{env::current_dir, path::PathBuf};
 
 mod commands;
@@ -95,7 +96,13 @@ enum DataCommands {
 }
 
 /// Run Kerblam! with a certain arguments list.
-pub fn kerblam(arguments: Args) -> anyhow::Result<()> {
+pub fn kerblam<'a, I, T>(arguments: I) -> anyhow::Result<()>
+where
+    I: Iterator<Item = T>,
+    T: Into<OsString> + Clone,
+{
+    let here = current_dir()?;
+    log::debug!("Kerblam! invoked in {here:?}");
     let args = Cli::try_parse_from(arguments)?;
 
     if let Command::New { path } = args.command {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,9 @@ use std::env::args;
 fn main() -> anyhow::Result<()> {
     env_logger::init();
 
-    kerblam::kerblam(args())?;
+    let args = args();
+
+    kerblam::kerblam(args.into_iter())?;
 
     Ok(())
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -462,7 +462,7 @@ impl KerblamTomlOptions {
             .code
             .clone()
             .and_then(|x| x.env_dir)
-            .unwrap_or_else(|| current_dir().unwrap().join("src/dockerfiles"));
+            .unwrap_or_else(|| current_dir().unwrap().join("src/containers"));
 
         find_files(env, None)
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -180,6 +180,9 @@ impl AsQuestion for GitCloneMethod {
     }
 }
 
+/// A small wrapper to run a certain shell command with some args
+///
+/// Provides none of the lower-level control of `run_protected_command`.
 pub fn run_command(
     location: Option<impl AsRef<Path>>,
     command: &str,
@@ -210,30 +213,6 @@ pub fn run_command(
             String::from_utf8(output.stderr).expect("Could not parse command output as UTF-8"),
         ))
     }
-}
-
-#[allow(dead_code)]
-pub fn clone_repo(
-    target: Option<impl AsRef<Path>>,
-    repo: &str,
-    method: GitCloneMethod,
-) -> Result<String> {
-    let target = target.map(|path| path.as_ref().to_path_buf());
-    let head = match method {
-        GitCloneMethod::Ssh => "git@github.com:",
-        GitCloneMethod::Https => "https://github.com/",
-    };
-
-    let path = match target {
-        None => ".".to_string(),
-        Some(ref path) => path.to_string_lossy().to_string(),
-    };
-
-    run_command(
-        target,
-        "git",
-        vec!["clone", format!("{}{}", head, repo).as_str(), &path],
-    )
 }
 
 pub fn fetch_gitignore(name: &str) -> Result<String> {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,0 +1,5 @@
+// Utils to setup, run and teardown tests
+mod utils;
+
+// Run
+mod test_run;

--- a/tests/test_run.rs
+++ b/tests/test_run.rs
@@ -52,7 +52,7 @@ fn get_default_files() -> Vec<File> {
         File::new("kerblam.toml", TEST_KERBLAM_TOML),
         File::new("src/pipes/make_pipe.makefile", TEST_MAKE_PIPE),
         File::new("src/pipes/shell_pipe.sh", TEST_SHELL_PIPE),
-        File::new("src/dockerfiles/default.dockerfile", TEST_DOCKER_FILE),
+        File::new("src/containers/default.dockerfile", TEST_DOCKER_FILE),
         File::new("src/pipes/error.sh", TEST_ERROR_SHELL_PIPE),
     ]
 }

--- a/tests/test_run.rs
+++ b/tests/test_run.rs
@@ -1,0 +1,78 @@
+use crate::utils::{assert_ok, init_log, setup_workdir, File};
+use chwd;
+use kerblam::kerblam;
+use rusty_fork::rusty_fork_test;
+
+// As cargo test runs a new *thread* at each test, multiple calls to kerblam!
+// may cause the `ctrlc` signal hook to be set multiple times (as it is
+// registered for the whole *process*, not each *thread*).
+// rusty-fork makes it so that each test is ran in its own *process*, so
+// this problem does not occur.
+
+static TEST_KERBLAM_TOML: &'static str = r#"
+[data.remote]
+"https://raw.githubusercontent.com/MrHedmad/kerblam/main/README.md" = "input_data.txt"
+"https://raw.githubusercontent.com/BurntSushi/ripgrep/master/README.md" = "alternate_input_data.txt"
+
+[data.profiles.alternate]
+"input_data.txt" = "alternate_input_data.txt"
+
+"#;
+
+static TEST_SHELL_PIPE: &'static str = r#"
+echo "Running shell pipe"
+mkdir -p ./data/out/
+cat ./data/in/input_data.txt | wc -l > ./data/out/line_count.txt
+"#;
+
+static TEST_MAKE_PIPE: &'static str = r#"
+.RECIPEPREFIX = > 
+all: ./data/out/line_count.txt
+
+./data/out/line_count.txt: ./data/in/input_data.txt
+> echo "Running make pipe"
+> mkdir -p ${@D}
+> cat $< | wc -l > $@
+
+"#;
+
+static TEST_DOCKER_FILE: &'static str = r#"
+FROM ubuntu:latest
+
+COPY . .
+"#;
+
+fn get_default_files() -> Vec<File> {
+    vec![
+        File::new("kerblam.toml", TEST_KERBLAM_TOML),
+        File::new("src/pipes/make_pipe.makefile", TEST_MAKE_PIPE),
+        File::new("src/pipes/shell_pipe.sh", TEST_SHELL_PIPE),
+        File::new("src/dockerfiles/default.dockerfile", TEST_DOCKER_FILE),
+    ]
+}
+
+rusty_fork_test! {
+    #[test]
+    fn test_shell_analysis() {
+        init_log();
+        let default_files = get_default_files();
+        let temp_dir = setup_workdir(default_files.iter());
+        let _flag = chwd::ChangeWorkingDirectory::change(&temp_dir).unwrap();
+
+        assert_ok(kerblam(vec!["", "data", "fetch"].iter()));
+        assert_ok(kerblam(vec!["", "run", "shell_pipe", "--local"].iter()));
+    }
+}
+
+rusty_fork_test! {
+    #[test]
+    fn test_make_analysis() {
+        init_log();
+        let default_files = get_default_files();
+        let temp_dir = setup_workdir(default_files.iter());
+        let _flag = chwd::ChangeWorkingDirectory::change(&temp_dir).unwrap();
+
+        assert_ok(kerblam(vec!["", "data", "fetch"].iter()));
+        assert_ok(kerblam(vec!["", "run", "make_pipe", "--local"].iter()));
+    }
+}

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,0 +1,124 @@
+use similar::{ChangeTag, TextDiff};
+use std::env::set_var;
+use std::fmt::{Debug, Write};
+use std::fs::{create_dir_all, read_to_string, write};
+use std::path::PathBuf;
+use std::slice::Iter;
+use tempfile::TempDir;
+
+// All of these functions are panic-heavy
+
+pub fn init_log() {
+    set_var("RUST_LOG", "debug");
+    let _ = env_logger::builder().is_test(true).try_init();
+}
+
+pub fn assert_ok<T, E>(value: Result<T, E>)
+where
+    E: Debug,
+    T: Debug,
+{
+    if value.is_ok() {
+        assert!(true);
+        return;
+    }
+    if value.is_err() {
+        eprintln!("{:?}", value.unwrap_err());
+        assert!(false);
+    }
+}
+
+/// Util to represent a file in the FS
+pub struct File {
+    path: PathBuf,
+    content: String,
+}
+
+#[allow(dead_code)]
+pub enum FileError {
+    NotFound,
+    Changed { diff: String },
+}
+
+#[allow(dead_code)]
+fn compute_diff(old: &str, new: &str) -> String {
+    let mut result = String::new();
+    let diff = TextDiff::from_lines(old, new);
+
+    for change in diff.iter_all_changes() {
+        let sign = match change.tag() {
+            ChangeTag::Delete => "-",
+            ChangeTag::Insert => "+",
+            ChangeTag::Equal => " ",
+        };
+        writeln!(result, "{}{}", sign, change).unwrap(); // writing to String never fails
+    }
+
+    result
+}
+
+impl File {
+    /// Write the content of the file to disk
+    pub fn write(&self) {
+        create_dir_all(self.path.parent().unwrap()).expect("Expected to be able to create dirs");
+
+        write(&self.path, &self.content).expect("Failed to write file!");
+    }
+
+    /// Does this file exist?
+    #[allow(dead_code)]
+    pub fn exists(&self) -> bool {
+        self.path.exists()
+    }
+
+    /// Was this file modified in any way from the original content?
+    #[allow(dead_code)]
+    pub fn check_modified_content(&self) -> Result<(), FileError> {
+        self.check_content(&self.content)
+    }
+
+    /// Check the content of this file for the expected content
+    #[allow(dead_code)]
+    pub fn check_content(&self, expected: &str) -> Result<(), FileError> {
+        if !self.exists() {
+            return Err(FileError::NotFound);
+        };
+
+        let content = read_to_string(&self.path).unwrap();
+        if content != expected {
+            let diff = compute_diff(expected, &content);
+            return Err(FileError::Changed { diff });
+        }
+
+        Ok(())
+    }
+
+    /// Convenience that builds the File from a &str path
+    pub fn new(path: &str, content: &str) -> Self {
+        Self {
+            path: PathBuf::from(path),
+            content: content.into(),
+        }
+    }
+}
+
+/// Setup a temporary working directory with a series of files
+///
+/// This function returns a TempDir. When it gets destroyed, the
+/// workdir is deleted as well.
+pub fn setup_workdir(files: Iter<File>) -> TempDir {
+    let temp_dir = TempDir::new().unwrap();
+
+    let new_files: Vec<File> = files
+        .map(|f| File {
+            path: temp_dir.path().join(&f.path),
+            content: f.content.clone(),
+        })
+        .collect();
+
+    for file in new_files {
+        file.write();
+    }
+
+    temp_dir
+}


### PR DESCRIPTION
This PR adds test support to Kerblam! in the form of integration and unit tests that can be run by `cargo test`.

Logs are initialized in tests by the `init_log` function so that debug traces can be printed.
`cargo test -- --nocapture` shows such logs even for non-failing tests.
