### PR TITLE
Add a `--yes` flag to `kerblam data clean`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ Kerblam! then allows you to:
 To transform a project to a Kerblam! project just make the kerblam.toml
 file yourself. To learn how, look at the section below.
 
+<div align="center">
+
+[✨ See usage examples of Kerblam! ✨](https://github.com/MrHedmad/kerblam-examples)
+
+</div>
+
 # Overview
 Kerblam! has the following commands:
 - :magic_wand: `kerblam new` can be used to create a new kerblam!

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -307,6 +307,10 @@ Kerblam! will consider as "remotely available" files that are present in the
 > If you want to preserve the empty folders left behind after cleaning,
 > pass the `--keep-dirs` flag to do just that.
 
+> [!TIP]
+> Kerblam! will ask for your confirmation before deleting the files.
+> If you're feeling bold, skip it with the `--yes` flag.
+
 ### `kerblam data pack` - Package and export your local data
 Say that you wish to send all your data folder to a colleague for inspection.
 You can `tar -czvf exported_data.tar.gz ./data/` and send your whole data folder,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,9 @@ enum DataCommands {
         #[arg(long, short('d'), action)]
         /// Do not delete locally present directories.
         keep_dirs: bool,
+        #[arg(long, short, action)]
+        /// Do not ask for any confirmation.
+        yes: bool,
     },
     // Pack local data for export to others
     Pack {
@@ -154,7 +157,8 @@ where
             Some(DataCommands::Clean {
                 keep_remote,
                 keep_dirs,
-            }) => clean_data(config, keep_remote, keep_dirs)?,
+                yes,
+            }) => clean_data(config, keep_remote, keep_dirs, yes)?,
             Some(DataCommands::Pack { output_path: path }) => package_data_to_archive(
                 config,
                 path.unwrap_or(here.join("data/data_export.tar.gz")),


### PR DESCRIPTION
<!--
Hello! Thanks for making a pull request. I'm just a comment that will not
be included in the final pull request reminding you to:
- Give the PR a nice title. It will be used in the changelog.
- Specify if you are fixing a specific issue in the text, for example:
   > This fixes #1234.
- Before merging, keep in mind the TODOs below.

Thanks for opening a PR! I appreciate it. You can delete this comment,
if you'd like!
-->

I needed to use `kerblam!` for scripting, and the prompt got in the way. This PR adds a `--yes` (or `-y`) flag to skip it.

## TODO
Before merging, tick all of these boxes:
- [X] `cargo check` passes without errors or warnings.
- [X] `cargo test` passes without errors or warnings.
- [X] Documentation is updated that reflect these changes.
  - [ ] This PR changes nothing that is reflected in docs.
- [X] @all-contributors is made aware of this PR.
