### PR TITLE
Allow docker runs in non-tty environments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,6 +81,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +555,15 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
@@ -680,7 +700,7 @@ version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.4",
  "rustix",
  "windows-sys 0.52.0",
 ]
@@ -714,6 +734,7 @@ name = "kerblam"
 version = "1.0.0-rc.0"
 dependencies = [
  "anyhow",
+ "atty",
  "chwd",
  "clap",
  "crossbeam-channel",
@@ -892,7 +913,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.4",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ lto = "thin"
 
 [dependencies]
 anyhow = "^1.0"
+atty = "0.2.14"
 clap = { version = "^4.4", features = ["derive"] }
 crossbeam-channel = "^0.5"
 ctrlc = "^3.4"

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -123,7 +123,13 @@ impl Executor {
             // This is a containerized run
             let backend: String = config.execution.backend.clone().into();
             let runtime_name = self.build_env(signal_receiver.clone(), &backend)?;
-            let mut partial: Vec<String> = stringify![vec![&backend, "run", "-it"]];
+            let mut partial: Vec<String> = if atty::is(atty::Stream::Stdout) {
+                // We are in a terminal. Run interactively
+                stringify![vec![&backend, "run", "--rm", "-it"]]
+            } else {
+                // We are not in a terminal. Run normally
+                stringify![vec![&backend, "run", "--rm"]]
+            };
             // We need to bind-mount the same data dirs as specified in the options
             let mounts = generate_bind_mount_strings(config);
             for mount in mounts {

--- a/tests/run_local_examples.rs
+++ b/tests/run_local_examples.rs
@@ -117,9 +117,14 @@ macro_rules! run_example_named {
                 // Take a snapshot of the contents of the repo
                 let snap = snapshot(&target).expect("Could not take snapshot of repo");
 
+                // Redirect 'kerblam' to the test kerblam bin
+                let test_bin = PathBuf::from(env!("CARGO_BIN_EXE_kerblam"));
+                let original_path = env!("PATH");
+
                 // Run the things
                 let code = Command::new("bash")
                     .args([target.join("run")])
+                    .env("PATH", format!("{}:{}", test_bin.parent().unwrap().to_string_lossy(), original_path))
                     .output()
                     .expect("Could not collect child output");
 
@@ -159,9 +164,14 @@ macro_rules! run_failing_example_named {
                 // Take a snapshot of the contents of the repo
                 let snap = snapshot(&target).expect("Could not take snapshot of repo");
 
+                // Redirect 'kerblam' to the test kerblam bin
+                let test_bin = PathBuf::from(env!("CARGO_BIN_EXE_kerblam"));
+                let original_path = env!("PATH");
+
                 // Run the things
                 let code = Command::new("bash")
                     .args([target.join("run")])
+                    .env("PATH", format!("{}:{}", test_bin.parent().unwrap().to_string_lossy(), original_path))
                     .output()
                     .expect("Could not collect child output");
 
@@ -186,3 +196,4 @@ macro_rules! run_failing_example_named {
 run_example_named!("basic_pipes");
 run_example_named!("basic_containers");
 run_failing_example_named!("safe_failure");
+run_example_named!("overview");


### PR DESCRIPTION
<!--
Hello! Thanks for making a pull request. I'm just a comment that will not
be included in the final pull request reminding you to:
- Give the PR a nice title. It will be used in the changelog.
- Specify if you are fixing a specific issue in the text, for example:
   > This fixes #1234.
- Before merging, keep in mind the TODOs below.

Thanks for opening a PR! I appreciate it. You can delete this comment,
if you'd like!
-->
Up to now, kerblam! always adds the `-it` flag to docker execution. This causes docker to fail if kerblam! is ever ran from a non-tty environment (such as when we run `cargo test`).
This causes docker to immediately die since it cannot allocate the pseudo-tty session.

This patch fixes it, by using `atty` and checking if we can connect to a tty (so we can use `-it`) or not (so we omit it).
The `atty` crate is pretty small, so it does not contribute much to compilation time.

It also updates tests:
- We use the correct test kerblam executable instead of the locally installed one (if any) to run `kerblam-examples`-style tests;
- The above fix makes some docker-using tests possible. Some were added in this patch.

## TODO
Before merging, tick all of these boxes:
- [X] `cargo test` passes without errors or warnings.
- [ ] Documentation is updated that reflect these changes.
  - [X] This PR changes nothing that is reflected in docs.
- [X] @all-contributors is made aware of this PR.
