### PR TITLE
Properly manage timestamps of profile files

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -3,6 +3,7 @@ on: [pull_request]
 
 env:
   RUST_LOG: debug
+  RUST_BACKTRACE: 1
 
 jobs:
   test:
@@ -13,4 +14,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --all-features
+      - run: cargo test --all-features -- --nocapture

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -854,6 +854,7 @@ dependencies = [
  "reqwest",
  "rusty-fork",
  "serde",
+ "serde_json",
  "similar",
  "tar",
  "tempfile",
@@ -1385,9 +1386,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -146,6 +161,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "chwd"
@@ -359,7 +387,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b467862cc8610ca6fc9a1532d7777cee0804e678ab45410897b9396495994a0b"
 dependencies = [
- "nix",
+ "nix 0.27.1",
  "windows-sys 0.52.0",
 ]
 
@@ -451,12 +479,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c6916888f6cb6350d2550b80fb63e734897a8498abe35cfb732b6487804b0"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -466,10 +510,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a576fc72ae164fca6b9db127eaa9a9dda0d61316034f33a0a0d4eda41f02b01d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "futures-sink"
@@ -489,8 +555,11 @@ version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -568,6 +637,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
 
 [[package]]
+name = "homedir"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22074da8bba2ef26fc1737ae6c777b5baab5524c2dc403b5c6a76166766ccda5"
+dependencies = [
+ "cfg-if",
+ "nix 0.26.4",
+ "serde",
+ "widestring",
+ "windows-sys 0.48.0",
+ "wmi",
+]
+
+[[package]]
 name = "http"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,6 +726,29 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -741,6 +847,7 @@ dependencies = [
  "filetime",
  "flate2",
  "git2",
+ "homedir",
  "indicatif",
  "log",
  "paste",
@@ -861,6 +968,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,6 +1014,19 @@ dependencies = [
 
 [[package]]
 name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+]
+
+[[package]]
+name = "nix"
 version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
@@ -905,6 +1034,15 @@ dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
  "libc",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0df0e5185db44f69b44f26786fe401b6c293d1907744beaa7fa62b2e5a517a"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1774,6 +1912,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
+name = "widestring"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "653f141f39ec16bba3c5abe400a0c60da7468261cc2cbf36805022876bc721a8"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,6 +1947,49 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core",
+ "windows-implement",
+ "windows-interface",
+ "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12168c33176773b86799be25e2a2ba07c7aab9968b37541f1094dbd7a60c8946"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d8dc32e0095a7eeccebd0e3f09e9509365ecb3fc6ac4d6f5f14a3f6392942d1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1953,6 +2140,20 @@ checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "wmi"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc2f0a4062ca522aad4705a2948fd4061b3857537990202a8ddd5af21607f79a"
+dependencies = [
+ "chrono",
+ "futures",
+ "log",
+ "serde",
+ "thiserror",
+ "windows",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ indicatif = "^0.17"
 log = "^0.4"
 reqwest = { version = "^0.11", default-features = false, features = ["json", "blocking", "rustls-tls"] }
 serde = { version = "^1.0", features = ["derive"] }
+serde_json = "1.0.115"
 tar = "0.4.40"
 tempfile = "^3.8"
 termimad = "0.29.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ ctrlc = "^3.4"
 env_logger = "^0.10"
 filetime = "^0.2"
 flate2 = "1.0.28"
+homedir = "0.2.1"
 indicatif = "^0.17"
 log = "^0.4"
 reqwest = { version = "^0.11", default-features = false, features = ["json", "blocking", "rustls-tls"] }

--- a/docs/src/tutorial/run.md
+++ b/docs/src/tutorial/run.md
@@ -114,6 +114,25 @@ In this way, you can detect from inside the pipeline if you are in a profile or 
 This is useful if you want to keep the outputs of different profiles separate,
 for instance.
 
+### File modification times when using profiles
+`make` tracks file creation times to determine if it has to re-run pipelines again.
+This means that if you move files around, like Kerblam! does when it applies
+profiles, `make` will always re-run your pipelines, even if you run the same
+pipeline with the same profile back-to-back.
+
+To avoid this, Kerblam! will keep track of the last-run profile in your
+projects and update the timestamps of the moved files
+**only when strictly necessary**.
+
+This means that the profile files will get updated timestamps only when they
+actually need to be updated, which is:
+- When you use a profile for the first time;
+- When you switch from one profile to a different one;
+- When you don't use a profile, but you just used one the previous run;
+
+To track what was the last profile used, Kerblam! creates a file in
+`$HOME/.cache/kerblam/` for each of your projects.
+
 ## Sending additional arguments to make or bash
 You can send additional arguments to either `make` or `bash` after what
 Kerblam! sets by default by specifying them after kerblam's own `run` arguments:
@@ -147,4 +166,3 @@ kerblam run my_pipe -- -- arg_1 arg_2 ...
 The first `--` is "eaten up" by Kerblam!, and the second one is passed to the
 containerization engine, telling it to pass `arg_1`, `arg_2` etc... as-is to
 the entrypoint.
-

--- a/docs/src/tutorial/run_containers.md
+++ b/docs/src/tutorial/run_containers.md
@@ -132,6 +132,6 @@ In this way, Kerblam! will run the containers with the proper paths.
 Sometimes, you want to skip using the build cache when executing a pipeline
 with a container executable.
 
-Using `kerblam run my_pipeline --skip-build-cache` will do just that: the
+Using `kerblam run my_pipeline --no-build-cache` will do just that: the
 build backend will be told not to use the cached layers for that build (with
 [the `--no-cache` flag](https://docs.docker.com/reference/cli/docker/image/build/#options)).

--- a/docs/src/tutorial/run_containers.md
+++ b/docs/src/tutorial/run_containers.md
@@ -127,3 +127,11 @@ In this way, Kerblam! will run the containers with the proper paths.
 > 
 > There is currently no way to configure a different working directory for every
 > specific dockerfile.
+
+### Skipping using cache
+Sometimes, you want to skip using the build cache when executing a pipeline
+with a container executable.
+
+Using `kerblam run my_pipeline --skip-build-cache` will do just that: the
+build backend will be told not to use the cached layers for that build (with
+[the `--no-cache` flag](https://docs.docker.com/reference/cli/docker/image/build/#options)).

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,0 +1,88 @@
+use std::env::current_dir;
+use std::fs::read_to_string;
+use std::hash::{DefaultHasher, Hash, Hasher};
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use anyhow::Result;
+use homedir::get_my_home;
+
+/// Return the cache file for the current directory
+///
+/// The location of the cache file is dependent on the hash of the path
+/// of the current directory, which generally is where the kerblam.toml
+/// file is.
+///
+/// This causes each project to have its own cache file.
+pub fn get_cache_path() -> Result<PathBuf> {
+    let cache_dir = match get_my_home() {
+        Ok(dir) => dir
+            .unwrap_or_else(|| PathBuf::from_str("/tmp").unwrap())
+            .join(".cache/kerblam"),
+        Err(_) => PathBuf::from_str("/tmp/.cache/kerblam").unwrap(),
+    };
+    if !cache_dir.exists() {
+        std::fs::create_dir_all(&cache_dir)?;
+    };
+    let path_hash = calc_hash(&current_dir().unwrap());
+    Ok(cache_dir.join(format!("{}", path_hash)))
+}
+
+/// Read the content of the cache file to a string
+/// Returns None if a cache cannot be found.
+pub fn get_cache() -> Option<String> {
+    let cache_file = get_cache_path().unwrap();
+    if !cache_file.exists() {
+        return None;
+    }
+
+    Some(read_to_string(cache_file).unwrap())
+}
+
+/// Save content to the cache
+pub fn write_cache(name: &str) -> Result<()> {
+    let cache_file = get_cache_path().unwrap();
+    std::fs::write(cache_file, name)?;
+
+    Ok(())
+}
+
+/// Check the name of the last profile run in this project and return
+/// True if it's the same as the current one, False otherwise.
+/// Returns None if there is no cache.
+///
+/// Also updates the cache to the new profile
+pub fn check_last_profile(current_profile: String) -> Option<bool> {
+    let last_profile = get_cache();
+
+    let result = last_profile
+        .clone()
+        .is_some_and(|x| x.trim() == current_profile);
+
+    write_cache(&current_profile).unwrap();
+
+    if last_profile.is_none() {
+        None
+    } else {
+        Some(result)
+    }
+}
+
+/// Delete from the cache the last profile used.
+///
+/// This currently just deletes the cache.
+pub fn delete_last_profile() -> Result<()> {
+    let cache_path = get_cache_path()?;
+
+    if cache_path.exists() {
+        std::fs::remove_file(cache_path)?;
+    }
+
+    Ok(())
+}
+
+fn calc_hash<T: Hash>(t: &T) -> u64 {
+    let mut s = DefaultHasher::new();
+    t.hash(&mut s);
+    s.finish()
+}

--- a/src/commands/package.rs
+++ b/src/commands/package.rs
@@ -132,7 +132,7 @@ pub fn package_pipe(config: KerblamTomlOptions, pipe: Pipe, package_name: &str) 
 
     // Create the 'name' file
     let name_file = temp_package.path().join("name");
-    let mut name_file_conn = File::create(&name_file)?;
+    let mut name_file_conn = File::create(name_file)?;
     write!(name_file_conn, "{}", package_name)?;
 
     let package = here.join(format!("{}.kerblam.tar", pipe_name));

--- a/src/commands/package.rs
+++ b/src/commands/package.rs
@@ -70,7 +70,7 @@ pub fn package_pipe(config: KerblamTomlOptions, pipe: Pipe, package_name: &str) 
     };
     let sigint_rec = setup_ctrlc_hook().expect("Failed to setup SIGINT hook!");
     let backend: String = config.execution.backend.clone().into();
-    let base_container = executor.build_env(sigint_rec, &backend)?;
+    let base_container = executor.build_env(sigint_rec, &backend, false)?;
     log::debug!("Base container name: {base_container:?}");
 
     // We now have the empty container. We can add our own layers.

--- a/src/commands/replay.rs
+++ b/src/commands/replay.rs
@@ -79,7 +79,7 @@ pub fn replay(
             package_config.input_data_dir()
         );
         let data = gunzip_file(&data_archive, &data_archive)?;
-        let data_archive_conn = File::open(&data)?;
+        let data_archive_conn = File::open(data)?;
         let mut data_archive = tar::Archive::new(data_archive_conn);
         data_archive.unpack(package_config.input_data_dir())?;
     };

--- a/src/commands/replay.rs
+++ b/src/commands/replay.rs
@@ -48,8 +48,8 @@ pub fn replay(
     let tag_name = match tag {
         Some(x) => x,
         None => {
-            if read_name.is_ok() {
-                read_name.unwrap()
+            if let Ok(name) = read_name {
+                name
             } else {
                 bail!("Could not read container name. Try running with --tag")
             }

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -146,6 +146,7 @@ pub fn kerblam_run_project(
     runtime_dir: &PathBuf,
     profile: Option<String>,
     ignore_container: bool,
+    skip_build_cache: bool,
     extra_args: Option<Vec<String>>,
 ) -> Result<String> {
     let pipe = if ignore_container {
@@ -245,7 +246,8 @@ pub fn kerblam_run_project(
     };
 
     // Execute the executor
-    let runtime_result = executor.execute(sigint_rec, &config, env_vars, extra_args);
+    let runtime_result =
+        executor.execute(sigint_rec, &config, env_vars, skip_build_cache, extra_args);
 
     // Undo the input file renaming
     if !unwinding_paths.is_empty() {

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -4,6 +4,7 @@ use std::env::current_dir;
 use std::fs::read_to_string;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::{Path, PathBuf};
+use std::str::FromStr;
 
 use crate::execution::{setup_ctrlc_hook, Executor, FileMover};
 use crate::options::KerblamTomlOptions;
@@ -55,7 +56,12 @@ fn infer_test_data(paths: Vec<PathBuf>) -> HashMap<PathBuf, PathBuf> {
 ///
 /// This causes each project to have its own cache file.
 pub fn get_cache_path() -> Result<PathBuf> {
-    let cache_dir = get_my_home()?.unwrap().join(".cache/kerblam");
+    let cache_dir = match get_my_home() {
+        Ok(dir) => dir
+            .unwrap_or_else(|| PathBuf::from_str("/tmp").unwrap())
+            .join(".cache/kerblam"),
+        Err(_) => PathBuf::from_str("/tmp/.cache/kerblam").unwrap(),
+    };
     if !cache_dir.exists() {
         std::fs::create_dir_all(&cache_dir)?;
     };

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -64,7 +64,7 @@ pub fn get_cache_path() -> Result<PathBuf> {
     if !cache_dir.exists() {
         std::fs::create_dir_all(&cache_dir)?;
     };
-    let path_hash = calc_hash(&mut current_dir().unwrap());
+    let path_hash = calc_hash(&current_dir().unwrap());
     Ok(cache_dir.join(format!("{}", path_hash)))
 }
 
@@ -262,11 +262,7 @@ pub fn kerblam_run_project(
         // as we move them around, or the make pipelines re-run from the
         // beginning even if we did nothing to them
         let cached_run = check_last_profile(profile);
-        let cached_run = if cached_run.is_none() {
-            false
-        } else {
-            cached_run.unwrap()
-        };
+        let cached_run = cached_run.unwrap_or(false);
         log::debug!("Checked cached profile: {}", cached_run);
 
         // Rename the paths that we found

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,17 +1,13 @@
 use std::collections::HashMap;
-use std::env::current_dir;
-use std::fs::read_to_string;
-use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::{Path, PathBuf};
-use std::str::FromStr;
 
+use crate::cache::{check_last_profile, delete_last_profile, get_cache};
 use crate::execution::{setup_ctrlc_hook, Executor, FileMover};
 use crate::options::KerblamTomlOptions;
 use crate::options::Pipe;
 
 use anyhow::{anyhow, bail, Result};
 use filetime::{set_file_mtime, FileTime};
-use homedir::get_my_home;
 
 /// Push a bit of a string to the end of this path
 ///
@@ -39,92 +35,6 @@ fn infer_test_data(paths: Vec<PathBuf>) -> HashMap<PathBuf, PathBuf> {
     }
 
     matches
-}
-
-/// NOTE: This chache-related stuff may be best moved to its own module and
-/// perhaps wrapped in a struct. The functions are broken up like this to be
-/// a bit more flexible if we need to add more than a single word in the cache
-/// in the future (like, using JSON or stuff like that).
-/// For now, it's so simple that just a few loose functions should be enough.
-
-/// Return the cache file for the current directory
-///
-/// The location of the cache file is dependent on the hash of the path
-/// of the current directory, which generally is where the kerblam.toml
-/// file is.
-///
-/// This causes each project to have its own cache file.
-pub fn get_cache_path() -> Result<PathBuf> {
-    let cache_dir = match get_my_home() {
-        Ok(dir) => dir
-            .unwrap_or_else(|| PathBuf::from_str("/tmp").unwrap())
-            .join(".cache/kerblam"),
-        Err(_) => PathBuf::from_str("/tmp/.cache/kerblam").unwrap(),
-    };
-    if !cache_dir.exists() {
-        std::fs::create_dir_all(&cache_dir)?;
-    };
-    let path_hash = calc_hash(&current_dir().unwrap());
-    Ok(cache_dir.join(format!("{}", path_hash)))
-}
-
-/// Read the content of the cache file to a string
-/// Returns None if a cache cannot be found.
-pub fn get_cache() -> Option<String> {
-    let cache_file = get_cache_path().unwrap();
-    if !cache_file.exists() {
-        return None;
-    }
-
-    Some(read_to_string(cache_file).unwrap())
-}
-
-/// Save content to the cache
-pub fn write_cache(name: &str) -> Result<()> {
-    let cache_file = get_cache_path().unwrap();
-    std::fs::write(cache_file, name)?;
-
-    Ok(())
-}
-
-/// Check the name of the last profile run in this project and return
-/// True if it's the same as the current one, False otherwise.
-/// Returns None if there is no cache.
-///
-/// Also updates the cache to the new profile
-pub fn check_last_profile(current_profile: String) -> Option<bool> {
-    let last_profile = get_cache();
-
-    let result = last_profile
-        .clone()
-        .is_some_and(|x| x.trim() == current_profile);
-
-    write_cache(&current_profile).unwrap();
-
-    if last_profile.is_none() {
-        None
-    } else {
-        Some(result)
-    }
-}
-
-/// Delete from the cache the last profile used.
-///
-/// This currently just deletes the cache.
-pub fn delete_last_profile() -> Result<()> {
-    let cache_path = get_cache_path()?;
-
-    if cache_path.exists() {
-        std::fs::remove_file(cache_path)?;
-    }
-
-    Ok(())
-}
-
-fn calc_hash<T: Hash>(t: &T) -> u64 {
-    let mut s = DefaultHasher::new();
-    t.hash(&mut s);
-    s.finish()
 }
 
 fn extract_profile_paths(

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -214,10 +214,16 @@ pub fn kerblam_run_project(
         // If we are not in a profile now, but we were before, we should
         // re-touch all the old profile paths just to be safe that the
         // whole pipeline is re-run again with the new data
-        let last_profile = get_cache();
-        if last_profile.is_some() {
+        let last_cache = get_cache();
+        if last_cache
+            .clone()
+            .is_some_and(|x| x.last_executed_profile.is_some())
+        {
             log::debug!("Should re-touch profile files.");
-            let profile_paths = extract_profile_paths(&config, &last_profile.unwrap())?;
+            let profile_paths = extract_profile_paths(
+                &config,
+                &last_cache.unwrap().last_executed_profile.unwrap(),
+            )?;
 
             for mover in profile_paths {
                 log::debug!("Touching {:?}", &mover.clone().get_from());

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -354,7 +354,7 @@ pub fn kerblam_run_project(
                 if res.success() {
                     Ok("Done!".into())
                 } else {
-                    Err(anyhow!("Process exited with error."))
+                    Err(anyhow!("Process exited with error: {res:?}"))
                 }
             }
             None => Err(anyhow!("Process killed.")),

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -1,4 +1,3 @@
-use log;
 use std::collections::HashMap;
 use std::env::current_dir;
 use std::fs::read_to_string;
@@ -103,9 +102,9 @@ pub fn check_last_profile(current_profile: String) -> Option<bool> {
     write_cache(&current_profile).unwrap();
 
     if last_profile.is_none() {
-        return None;
+        None
     } else {
-        return Some(result);
+        Some(result)
     }
 }
 

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -253,20 +253,31 @@ impl Executor {
 
         let containerfile_path = containerfile_path.as_os_str().to_string_lossy().to_string();
 
-        let skip_cache = if no_cache { "--no-cache" } else { "" };
+        let build_args: Vec<&str> = if no_cache {
+            vec![
+                "build",
+                "-f",
+                containerfile_path.as_str(),
+                "--tag",
+                env_name.as_str(),
+                "--no-cache",
+                ".",
+            ]
+        } else {
+            vec![
+                "build",
+                "-f",
+                containerfile_path.as_str(),
+                "--tag",
+                env_name.as_str(),
+                ".",
+            ]
+        };
 
         let builder = || {
             Command::new(backend)
                 // If the `self.env` path is not UTF-8 I'll eat my hat.
-                .args([
-                    "build",
-                    "-f",
-                    containerfile_path.as_str(),
-                    "--tag",
-                    env_name.as_str(),
-                    skip_cache,
-                    ".",
-                ])
+                .args(&build_args)
                 .stdout(Stdio::inherit())
                 .stdin(Stdio::inherit())
                 .stderr(Stdio::inherit())

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -10,7 +10,7 @@ use crate::options::KerblamTomlOptions;
 
 use anyhow::{anyhow, bail, Context, Result};
 use crossbeam_channel::{bounded, Receiver};
-use ctrlc;
+
 use filetime::{set_file_mtime, FileTime};
 
 // TODO: I think we can add all cleanup code to `Drop`, so that a lot of these
@@ -181,7 +181,7 @@ impl Executor {
 
         if extra_args.is_some() {
             log::debug!("Appending extra command arguments...");
-            command_args.extend(extra_args.unwrap().into_iter());
+            command_args.extend(extra_args.unwrap());
         }
 
         log::debug!("Executor command arguments: {:?}", command_args);

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -151,7 +151,9 @@ impl Executor {
                     "make",
                     &runtime_name,
                     "-f",
-                    &format!("{}/executor", workdir)
+                    &format!("{}/executor", workdir),
+                    "-C",
+                    &workdir
                 ]),
                 ExecutionStrategy::Shell => stringify!(vec![
                     "--entrypoint",

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -378,10 +378,12 @@ impl FileMover {
     ///
     /// Works identically to `mv`, but returns a new `FileMover` that can be
     /// used to quickly undo the move.
-    pub fn rename(self) -> Result<FileMover> {
+    pub fn rename(self, update_time: bool) -> Result<FileMover> {
         log::debug!("Moving {:?} to {:?}", self.from, self.to);
         fs::rename(&self.from, &self.to)?;
-        set_file_mtime(&self.to, FileTime::now())?;
+        if update_time {
+            set_file_mtime(&self.to, FileTime::now())?;
+        }
 
         Ok(self.invert())
     }
@@ -415,6 +417,14 @@ impl FileMover {
             from: self.to,
             to: self.from,
         }
+    }
+
+    pub fn get_from(self) -> PathBuf {
+        self.from.clone()
+    }
+    #[allow(dead_code)]
+    pub fn get_to(self) -> PathBuf {
+        self.to.clone()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ enum DataCommands {
 }
 
 /// Run Kerblam! with a certain arguments list.
-pub fn kerblam<'a, I, T>(arguments: I) -> anyhow::Result<()>
+pub fn kerblam<I, T>(arguments: I) -> anyhow::Result<()>
 where
     I: Iterator<Item = T>,
     T: Into<OsString> + Clone,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ use std::env::set_current_dir;
 use std::ffi::OsString;
 use std::{env::current_dir, path::PathBuf};
 
+mod cache;
 mod commands;
 mod execution;
 mod options;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,9 @@ enum Command {
         /// Do not run in container even if a container is available
         #[arg(long, short, action)]
         local: bool,
+        /// Skip using build cache if running in containers.
+        #[arg(long = "skip-build-cache", action)]
+        skip_build_cache: bool,
         /// Command line arguments to be passed to child process
         #[clap(last = true, allow_hyphen_values = true)]
         extra_args: Option<Vec<String>>,
@@ -182,6 +185,7 @@ where
             profile,
             local,
             desc,
+            skip_build_cache,
             extra_args,
         } => {
             let pipe = find_pipe_by_name(&config, module_name)?;
@@ -195,6 +199,7 @@ where
                 &current_dir().unwrap(),
                 profile,
                 local,
+                skip_build_cache,
                 extra_args,
             )?;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ enum Command {
         #[arg(long, short, action)]
         local: bool,
         /// Skip using build cache if running in containers.
-        #[arg(long = "skip-build-cache", action)]
+        #[arg(long = "no-build-cache", action)]
         skip_build_cache: bool,
         /// Command line arguments to be passed to child process
         #[clap(last = true, allow_hyphen_values = true)]

--- a/src/options.rs
+++ b/src/options.rs
@@ -216,12 +216,10 @@ impl Display for Pipe {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let container_prefix = if self.env_path.is_none() {
             "◾"
+        } else if self.env_path.clone().unwrap().file_stem().unwrap() == "default" {
+            "🐟"
         } else {
-            if self.env_path.clone().unwrap().file_stem().unwrap() == "default" {
-                "🐟"
-            } else {
-                "🐋"
-            }
+            "🐋"
         };
         let desc_prefix = if self
             .description()
@@ -416,7 +414,7 @@ impl KerblamTomlOptions {
         let default_dockerfile: Option<PathBuf> = envs_names
             .iter()
             .find(|(name, _)| name == "default")
-            .and_then(|(_, path)| Some(path.to_owned()));
+            .map(|(_, path)| path.to_owned());
 
         for (pipe_name, pipe_path) in pipes_names {
             let mut found = false;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -432,7 +432,7 @@ pub fn tar_files(files: Vec<PathBuf>, strip: impl AsRef<Path>, target: PathBuf) 
     let mut data_tarball = tar::Builder::new(data_conn);
 
     for item in files {
-        let inner = item.strip_prefix(&strip)?;
+        let inner = item.strip_prefix(strip)?;
         log::debug!("Adding {item:?} as {inner:?} to {data_tar:?}...");
         data_tarball.append_path_with_name(&item, inner)?;
     }

--- a/tests/run_local_examples.rs
+++ b/tests/run_local_examples.rs
@@ -1,5 +1,3 @@
-use git2;
-use paste;
 use std::collections::HashMap;
 use std::env::set_current_dir;
 use std::mem::drop;
@@ -8,7 +6,7 @@ use std::process::Command;
 use std::{fs, io};
 use tempfile::TempDir;
 
-const EXAMPLE_REPO: &'static str = "https://github.com/MrHedmad/kerblam-examples.git";
+const EXAMPLE_REPO: &str = "https://github.com/MrHedmad/kerblam-examples.git";
 
 /// Setup local tests by cloning the example repo.
 fn setup_test() -> TempDir {
@@ -22,7 +20,7 @@ fn setup_test() -> TempDir {
     fetcher.fetch_options(clone_options);
 
     fetcher
-        .clone(EXAMPLE_REPO, &target.path())
+        .clone(EXAMPLE_REPO, target.path())
         .expect("Could not clone remote repo.");
 
     target

--- a/tests/test_run.rs
+++ b/tests/test_run.rs
@@ -1,5 +1,5 @@
 use crate::utils::{assert_ok, init_log, setup_workdir, File};
-use chwd;
+
 use kerblam::kerblam;
 use rusty_fork::rusty_fork_test;
 
@@ -18,7 +18,7 @@ use rusty_fork::rusty_fork_test;
 //
 // Keep that in mind.
 
-static TEST_KERBLAM_TOML: &'static str = r#"
+static TEST_KERBLAM_TOML: &str = r#"
 [data.remote]
 "https://raw.githubusercontent.com/MrHedmad/kerblam/main/README.md" = "input_data.txt"
 "https://raw.githubusercontent.com/BurntSushi/ripgrep/master/README.md" = "alternate_input_data.txt"
@@ -28,18 +28,18 @@ static TEST_KERBLAM_TOML: &'static str = r#"
 
 "#;
 
-static TEST_SHELL_PIPE: &'static str = r#"
+static TEST_SHELL_PIPE: &str = r#"
 echo "Running shell pipe"
 mkdir -p ./data/out/
 cat ./data/in/input_data.txt | wc -l > ./data/out/line_count.txt
 "#;
 
-static TEST_ERROR_SHELL_PIPE: &'static str = r#"
+static TEST_ERROR_SHELL_PIPE: &str = r#"
 echo "Running error shell pipe"
 exit 1
 "#;
 
-static TEST_MAKE_PIPE: &'static str = r#"
+static TEST_MAKE_PIPE: &str = r#"
 .RECIPEPREFIX = > 
 all: ./data/out/line_count.txt
 
@@ -50,7 +50,7 @@ all: ./data/out/line_count.txt
 
 "#;
 
-static TEST_DOCKER_FILE: &'static str = r#"
+static TEST_DOCKER_FILE: &str = r#"
 FROM ubuntu:latest
 
 COPY . .
@@ -74,8 +74,8 @@ rusty_fork_test! {
         let temp_dir = setup_workdir(default_files.iter());
         let _flag = chwd::ChangeWorkingDirectory::change(&temp_dir).unwrap();
 
-        assert_ok(kerblam(vec!["", "data", "fetch"].iter()));
-        assert_ok(kerblam(vec!["", "run", "shell_pipe", "--local"].iter()));
+        assert_ok(kerblam(["", "data", "fetch"].iter()));
+        assert_ok(kerblam(["", "run", "shell_pipe", "--local"].iter()));
     }
 }
 
@@ -87,8 +87,8 @@ rusty_fork_test! {
         let temp_dir = setup_workdir(default_files.iter());
         let _flag = chwd::ChangeWorkingDirectory::change(&temp_dir).unwrap();
 
-        assert_ok(kerblam(vec!["", "data", "fetch"].iter()));
-        assert_ok(kerblam(vec!["", "run", "make_pipe", "--local"].iter()));
+        assert_ok(kerblam(["", "data", "fetch"].iter()));
+        assert_ok(kerblam(["", "run", "make_pipe", "--local"].iter()));
     }
 }
 
@@ -101,7 +101,7 @@ rusty_fork_test! {
         let temp_dir = setup_workdir(default_files.iter());
         let _flag = chwd::ChangeWorkingDirectory::change(&temp_dir).unwrap();
 
-        assert_ok(kerblam(vec!["", "data", "fetch"].iter()));
-        assert_ok(kerblam(vec!["", "run", "error", "--local"].iter()));
+        assert_ok(kerblam(["", "data", "fetch"].iter()));
+        assert_ok(kerblam(["", "run", "error", "--local"].iter()));
     }
 }


### PR DESCRIPTION
Before now, when switching profiles, all the timestamps of the moved files would be updated. This causes `make` to re-run for every profiled run even though the same run is repeatedly executed.

To avoid this, Kerblam! now makes a file with the name of the last-used profile in `~/.cache/kerblam/...`. The filename is the hash of the project path, so that each project gets one cache file.

If kerblam detects that the same profile was used twice in a row, it skips updating the timestamps. If a normal run is executed, this cache is deleted and all the input files are re-touched (as if they were moved) to re-trigger the pipeline. This should prevent having to `data clean` every time a profile is switched.

This PR fixes issue #40.
<!--
Hello! Thanks for making a pull request. I'm just a comment that will not
be included in the final pull request reminding you to:
- Give the PR a nice title. It will be used in the changelog.
- Specify if you are fixing a specific issue in the text, for example:
   > This fixes #1234.
- Before merging, keep in mind the TODOs below.

Thanks for opening a PR! I appreciate it. You can delete this comment,
if you'd like!
-->

## TODO
Before merging, tick all of these boxes:
- [X] `cargo test -- --include-ignored` passes without errors or warnings.
- [X] Documentation is updated that reflect these changes.
  - [ ] This PR changes nothing that is reflected in docs.
- [X] @all-contributors is made aware of this PR.
