### PR TITLE
Make properly changes working directory following kerblam.toml in docker

### DIFF
--- a/src/execution.rs
+++ b/src/execution.rs
@@ -151,7 +151,9 @@ impl Executor {
                     "make",
                     &runtime_name,
                     "-f",
-                    &format!("{}/executor", workdir)
+                    &format!("{}/executor", workdir),
+                    "-C",
+                    &workdir
                 ]),
                 ExecutionStrategy::Shell => stringify!(vec![
                     "--entrypoint",


### PR DESCRIPTION
This hotfix fixes a bug where `make` was not changing working directory properly based on the
```toml
[execution]
workdir = /some/workdir
```
kerblam setting.

This slipped through due to #91.