### PR TITLE
fix: no profiles no longer prevents using test profile

### DIFF
--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -47,16 +47,16 @@ fn extract_profile_paths(
     check_existance: bool,
 ) -> Result<Vec<FileMover>> {
     let root_dir = config.input_data_dir();
-    // The call here was broken in 2 because the last `ok_or` makes a temporary
-    // reference that does not live enough until the 'profile.iter()' call
-    // later on. I'm not sure why this is the case, but separating the
-    // calls fixes it.
-    let mut profiles = config
-        .clone()
-        .data
-        .ok_or(anyhow!("Missing 'data' field!"))?
-        .profiles
-        .ok_or(anyhow!("Missing 'profiles' field!"))?;
+
+    // If there are no profiles, an empty hashmap is OK intead:
+    // we can add the default "test" profile anyway.
+    let mut profiles = {
+        let data = config.clone().data;
+        match data {
+            Some(x) => x.profiles.unwrap_or(HashMap::new()),
+            None => HashMap::new(),
+        }
+    };
 
     // add the default 'test' profile
     if !profiles.keys().any(|x| x == "test") {


### PR DESCRIPTION
<!--
Hello! Thanks for making a pull request. I'm just a comment that will not
be included in the final pull request reminding you to:
- Give the PR a nice title. It will be used in the changelog.
- Specify if you are fixing a specific issue in the text, for example:
   > This fixes #1234.
- Before merging, keep in mind the TODOs below.

Thanks for opening a PR! I appreciate it. You can delete this comment,
if you'd like!
-->
This fixes issue #103. The issue was that if no `profiles` (or `data`) fields were found, we crashed early. This was ok before the default test profile was added. Now, instead of crashing, we create a new empty profiles hashmap, so that we can (potentially) populate it later.

## TODO
Before merging, tick all of these boxes:
- [X] `cargo test -- --include-ignored` passes without errors or warnings.
- [ ] Documentation is updated that reflect these changes.
  - [X] This PR changes nothing that is reflected in docs.
- [X] @all-contributors is made aware of this PR.
