### PR TITLE
Add more specific gitignores for data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ Possible sections are "Added", "Changed", "Deprecated", "Removed", "Fixed" and
 Versions are listed in reverse chronological order, with the most recent at
 the top. Non pre-release versions sometimes have an associated name.
 
+## [Unreleased]
+
+### New
+- `kerblam new` now creates additional gitignore files in the data folder to
+  include the data folders themselves but ignore all files inside them.
+  Data files or folders that need to be committed to version control need to
+  be explicitly listed in the `.gitignore` files in the appropriate place.
+
 ## [v1.0.0] - 2024-07-12
 
 This is the first official release of Kerblam! Hurray!

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,15 +43,16 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
@@ -63,27 +64,27 @@ checksum = "2faccea4cc4ab4a667ce676a30e8ec13922a692c99bb8f5b11f1502c72e04220"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -223,9 +224,9 @@ checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "console"
@@ -801,14 +802,20 @@ checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
  "hermit-abi",
- "rustix",
+ "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -836,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "kerblam"
-version = "1.0.0-rc.3"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "chwd",
@@ -1821,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcpkg"
@@ -2167,9 +2174,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winnow"
-version = "0.5.37"
+version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cad8365489051ae9f054164e459304af2e7e9bb407c958076c8bf4aef52da5"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,15 @@ url = { version = "^2.5", features = ["serde"] }
 version-compare = "^0.1"
 walkdir = "^2.4"
 
+
+[dev-dependencies]
+chwd = "0.2.0"
+git2 = "0.18.2"
+paste = "1.0.14"
+rusty-fork = "0.3.0"
+serial_test = "3.1.1"
+similar = "2.4.0"
+
 # Config for 'cargo dist'
 [workspace.metadata.dist]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
@@ -70,15 +79,5 @@ installers = ["shell"]
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-unknown-linux-musl"]
 # Publish jobs to run in CI
 pr-run-mode = "plan"
-# Whether cargo-dist should create a Github Release or use an existing draft
-create-release = true
 # Whether to install an updater program
 install-updater = true
-
-[dev-dependencies]
-chwd = "0.2.0"
-git2 = "0.18.2"
-paste = "1.0.14"
-rusty-fork = "0.3.0"
-serial_test = "3.1.1"
-similar = "2.4.0"

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -13,10 +13,22 @@ pub fn create_kerblam_project(dir: &PathBuf) -> Result<()> {
         "./src/workflows",
         "./src/dockerfiles",
     ];
-    let mut files_to_create: Vec<(&str, String)> = vec![(
-        "./kerblam.toml",
-        format!("[meta]\nversion = \"{}\"\n", VERSION),
-    )];
+
+    let base_data_gitignore: &str =
+        "# Ignore everything in this directory\n*\n# Except this file\n!.gitignore\n";
+
+    let mut files_to_create: Vec<(&str, String)> = vec![
+        (
+            "./kerblam.toml",
+            format!("[meta]\nversion = \"{}\"\n", VERSION),
+        ),
+        ("./data/in/.gitignore", base_data_gitignore.to_string()),
+        ("./data/out/.gitignore", base_data_gitignore.to_string()),
+        (
+            "./data/.gitignore",
+            format!("{}\n!in/\n!out/", base_data_gitignore),
+        ),
+    ];
     // Having this to be a Vec<String> makes all sorts of problems since most
     // commands are hardcoded &str, and we need to go back and forth.
     // Probably can be fixed by generics?

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -159,7 +159,13 @@ pub fn create_kerblam_project(dir: &PathBuf) -> Result<()> {
     for (command, args) in commands_to_run {
         match utils::run_command(Some(dir), command, args.iter().map(|x| &**x).collect()) {
             Ok(_) => (),
-            Err(e) => eprintln!("{}", e),
+            Err(e) => {
+                eprintln!(
+                    "❌ Couldn't execute command '{}': {}. Ignoring.",
+                    format!("{} {}", command, args.join(" ")),
+                    e
+                )
+            }
         }
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -205,8 +205,7 @@ pub fn run_command(
     let output = Command::new(command)
         .current_dir(location.unwrap_or(PathBuf::from_str("./").unwrap()))
         .args(args)
-        .output()
-        .expect("Failed to spawn process");
+        .output()?;
 
     if output.status.success() {
         println!(" Done!");


### PR DESCRIPTION
<!--
Hello! Thanks for making a pull request. I'm just a comment that will not
be included in the final pull request reminding you to:
- Give the PR a nice title. It will be used in the changelog.
- Specify if you are fixing a specific issue in the text, for example:
   > This fixes #1234.
- Before merging, keep in mind the TODOs below.

Thanks for opening a PR! I appreciate it.
You can delete this comment, if you'd like!
-->

This PR adds some more defaults to `kerblam new` so that it creates proper gitignores to ignore data files by default. You sort of expect kerblam to do this on its own, but it didn't. Now, the `data`, `data/in`, `data/out` dirs are included, but their content isn't.

## TODO
Before merging, tick all of these boxes:
- [X] `cargo test -- --include-ignored` passes without errors or warnings.
- [X] The [`CHANGELOG.md`](https://github.com/MrHedmad/kerblam/blob/main/CHANGELOG.md) has been updated to reflect these changes.
- [X] Documentation is updated that reflect these changes, or this PR changes nothing that is reflected in the docs.
- [X] @all-contributors is made aware of this PR, or I am already in the [all contributors list](https://github.com/MrHedmad/kerblam/blob/main/CONTRIBUTING.md#all-contributors).
