### PR TITLE
Scratch folder for temporary data moves when using profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ the top. Non pre-release versions sometimes have an associated name.
 ### Added
 - Added the `--dry-run` option to `kerblam data clean` to only show the files
   that will be deleted without actually doing anything to them.
+- When using a profile, specifying `"_"` as target will simply temporarily hide
+  the file for the duration of the workflow.
+  For example `"test.txt" = "_"` will temporarily remove the `"test.txt"` file
+  from its original position (it will be moved to `.kerblam/scratch`).
+
+### Changed
+- The way that profiles are handled was changed.
+  Now, the original files are moved to `.kerblam/scratch/` during the workflow,
+  instead of remaining in the original directory (and being renamed `.original`).
 
 ## [v1.1.1] - 2024-10-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f30e7476521f6f8af1a1c4c0b8cc94f0bee37d91763d0ca2665f299b6cd8aec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +867,7 @@ dependencies = [
  "indicatif",
  "log",
  "paste",
+ "rand",
  "reqwest",
  "rusty-fork",
  "serde",
@@ -1166,6 +1173,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1187,6 +1203,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -2217,4 +2263,25 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "rustix",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ flate2 = "1.0.28"
 homedir = "0.2.1"
 indicatif = "^0.17"
 log = "^0.4"
+rand = "0.8.5"
 reqwest = { version = "^0.11", default-features = false, features = ["json", "blocking", "rustls-tls"] }
 serde = { version = "^1.0", features = ["derive"] }
 serde_json = "1.0.115"

--- a/docs/src/manual/run.md
+++ b/docs/src/manual/run.md
@@ -89,12 +89,12 @@ kerblam run process_csv --profile alternate
 > by default `data/in`.
 
 Under the hood, Kerblam! will:
-- Rename `input.csv` to `input.csv.original`;
+- Move `input.csv` to a temporary directory in the root of the project named `.kerblam/scratch`,
+  adding a very small salt string to its name (to avoid potential name collisions);
 - Move `different_input.csv` to `input.csv`;
 - Run the analysis as normal;
-- When the run ends (it finishes, it crashes or you kill it), Kerblam! will undo both actions:
-  it moves `different_input.csv` back to its original place and
-  renames `input.csv.original` back to `input.csv`.
+- When the run ends (it finishes, it crashes or you kill it), Kerblam! will restore the original state:
+  it moves both `different_input.csv` and `input.csv.<salt>` back to their original places.
 
 This effectively causes the workflow to run with different input data.
 

--- a/src/commands/new.rs
+++ b/src/commands/new.rs
@@ -8,6 +8,7 @@ use crate::VERSION;
 pub fn create_kerblam_project(dir: &PathBuf) -> Result<()> {
     let dirs_to_create: Vec<&str> = vec![
         "",
+        "./.kerblam",
         "./data/in",
         "./data/out",
         "./src/workflows",
@@ -35,6 +36,9 @@ pub fn create_kerblam_project(dir: &PathBuf) -> Result<()> {
     let mut commands_to_run: Vec<(&str, Vec<String>)> = vec![];
     commands_to_run.push(("git", vec![String::from("init")]));
     let mut gitignore_content: Vec<String> = vec![];
+    // We always ignore the .kerblam directory
+    gitignore_content.push(".kerblam".to_string());
+
     // Ask for user input
     // I defined `dirs_to_create` before so that if we ever have to add to them
     // dynamically we can do so here.

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -441,11 +441,11 @@ impl FileMover {
         }
     }
 
-    pub fn get_from(self) -> PathBuf {
+    pub fn get_from(&self) -> PathBuf {
         self.from.clone()
     }
     #[allow(dead_code)]
-    pub fn get_to(self) -> PathBuf {
+    pub fn get_to(&self) -> PathBuf {
         self.to.clone()
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -11,6 +11,7 @@ use std::process::Command;
 use std::str::FromStr;
 use termimad::{minimad, MadSkin};
 
+use rand::distributions::{Alphanumeric, DistString};
 use version_compare::Version;
 use walkdir::{self, DirEntry};
 
@@ -514,9 +515,16 @@ pub fn update_timestamps(path: &PathBuf) -> anyhow::Result<()> {
 ///
 /// Useful if you want to add an extension to the path.
 /// Requires a clone.
+#[allow(dead_code)]
 pub fn push_fragment(buffer: impl AsRef<Path>, ext: &str) -> PathBuf {
     let buffer = buffer.as_ref();
     let mut path = buffer.as_os_str().to_owned();
     path.push(ext);
     path.into()
+}
+
+/// Get a random alphanumerical string some characters long
+#[allow(dead_code)]
+pub fn get_salt(length: usize) -> String {
+    Alphanumeric.sample_string(&mut rand::thread_rng(), length)
 }


### PR DESCRIPTION
<!--
Hello! Thanks for making a pull request. I'm just a comment that will not
be included in the final pull request reminding you to:
- Give the PR a nice title. It will be used in the changelog.
- Specify if you are fixing a specific issue in the text, for example:
   > This fixes #1234.
- Before merging, keep in mind the TODOs below.

Thanks for opening a PR! I appreciate it.
You can delete this comment, if you'd like!
-->
Currently, the logic for applying profiles is as follows:
- Get which files have to be moved;
- Move originals to `**/*.original`;
- Move temporary to originals;
- Run the workflow;
- Revert the profile.

This PR changes this to:
- Get which files have to be moved;
- Move originals to `.kerblam/scratch/*.<random salt>`;
- Move temporary to originals;
- Run the workflow;
- Revert the profile.

This has two benefits:
- First, we can fix #76, by simply omitting to move the temporary files to the originals;
- Second, it makes sense that the original files would "disappear" when running a profile: you might list all files in a folder, and in the current implementation you would find the `*.original` still in the directory, which you might not be expecting.

While the second benefit might not be too useful, it might still be a desirable functionality.

## TODO
Before merging, tick all of these boxes:
- [x] `cargo test -- --include-ignored` passes without errors or warnings.
- [x] The [`CHANGELOG.md`](https://github.com/MrHedmad/kerblam/blob/main/CHANGELOG.md) has been updated to reflect these changes.
- [x] Documentation is updated that reflect these changes, or this PR changes nothing that is reflected in the docs.
- [x] @all-contributors is made aware of this PR, or I am already in the [all contributors list](https://github.com/MrHedmad/kerblam/blob/main/CONTRIBUTING.md#all-contributors).
