### PR TITLE
Allow non-fetcheable remote files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ the top. Non pre-release versions sometimes have an associated name.
   the file for the duration of the workflow.
   For example `"test.txt" = "_"` will temporarily remove the `"test.txt"` file
   from its original position (it will be moved to `.kerblam/scratch`).
+- When specifying remote files, using `"_"` as URL will tell Kerblam! to skip
+  fetching the file with `kerblam data fetch`, but will still treat it as
+  remote for all other purposes (e.g. for `kerblam data clean`).
+  This allows the user to use non-canonical fetching methods.
 
 ### Changed
 - The way that profiles are handled was changed.

--- a/docs/src/manual/fetch_data.md
+++ b/docs/src/manual/fetch_data.md
@@ -27,3 +27,28 @@ each file that you wish to be downloaded.
 >
 > Kerblam! will, however, warn you before acting, telling you that it is about
 > to do something potentially unwanted, and giving you the chance to abort.
+
+## Unfetcheable data
+Sometimes, a simple GET request is not enough to fetch your data.
+Perhaps you need some complicated login, or you use specific software to fetch
+your remote data.
+You can still tell Kerblam! that a file is remote, but that Kerblam! cannot
+directly fetch it: this way you can use all other Kerblam! features but
+"opt out" of the fetching one.
+
+To do this, simply specify `"_"` as the remote URL in the `kerblam.toml` file:
+```toml
+[data.remote]
+"https://example.com/" = "remote_file.txt"
+"_" = "unfetcheable_file.txt"
+```
+
+If you run `kerblam data fetch` with the above command, you'll fetch the
+`remote_file.txt`, but not `unfetcheable_file.txt` (and Kerblam! will remind
+you of that).
+
+> [!NOTE]
+> Remember that [Kerblam! replay packages](./package_pipes.md) will fetch
+> remote data for you before running the packaged workflow.
+> If an unfetcheable file is needed by the packaged workflow, be sure to fetch
+> it *inside* the workflow itself before running the computation proper.

--- a/src/commands/data.rs
+++ b/src/commands/data.rs
@@ -217,6 +217,44 @@ pub fn fetch_remote_data(config: KerblamTomlOptions) -> Result<()> {
         return Ok(());
     }
 
+    // Send a message reminding the user that there are some unfetcheable remote files
+    let non_fetcheable: Vec<&RemoteFile> = remote_files
+        .iter()
+        .filter_map(|x| {
+            if x.path.to_str().unwrap() == "_" {
+                Some(x)
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if !non_fetcheable.is_empty() {
+        if non_fetcheable.len() <= 5 {
+            let names: Vec<&str> = non_fetcheable
+                .into_iter()
+                .map(|x| x.to_owned().path.to_str().unwrap())
+                .collect();
+            eprintln!(
+                "There are {} remote files that Kerblam! cannot fetch: {}",
+                names.len(),
+                names.join(", ")
+            );
+        } else {
+            eprintln!(
+                "There are {} remote files that Kerblam! cannot fetch",
+                non_fetcheable.len(),
+            );
+        }
+    }
+
+    let remote_files: Vec<RemoteFile> = remote_files
+        .into_iter()
+        .filter(|x| x.path.to_str().unwrap() != "_")
+        .collect();
+
+    log::debug!("Fetching files: {:?}", remote_files);
+
     // Check if any remote files will be saved somewhere else than the
     // input data dir. If so, warn the user before continuing.
     let data_dir = config.input_data_dir();


### PR DESCRIPTION
This PR adds the ability for Kerblam! to allow non-fetcheable remote files.
This is done by specifying "_" as the URL, so that Kerblam! will skip the GET request, but still treat the local file as remote for all other purposes.
This required some restructuring of how `RemoteFile` works under the hood, and how `kerblam.toml` is parsed.

## TODO
Before merging, tick all of these boxes:
- [x] `cargo test -- --include-ignored` passes without errors or warnings.
- [x] The [`CHANGELOG.md`](https://github.com/MrHedmad/kerblam/blob/main/CHANGELOG.md) has been updated to reflect these changes.
- [x] Documentation is updated that reflect these changes, or this PR changes nothing that is reflected in the docs.
- [x] @all-contributors is made aware of this PR, or I am already in the [all contributors list](https://github.com/MrHedmad/kerblam/blob/main/CONTRIBUTING.md#all-contributors).
