### PR TITLE
The ctrl-c hook is now a static global variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ the top. Non pre-release versions sometimes have an associated name.
   Now, the original files are moved to `.kerblam/scratch/` during the workflow,
   instead of remaining in the original directory (and being renamed `.original`).
 
+### Fixed
+- Fixed a bug that occurred if you used a profile in a run, then deleted that
+  profile and run again with no profile selected. Kerblam! wanted to re-touch
+  your old profile files for you (to trigger workflows), but it failed (since
+  you deleted the profile). Now, the error is ignored, and Kerblam! simply
+  complains with a warning.
+
 ## [v1.1.1] - 2024-10-14
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -865,6 +865,7 @@ dependencies = [
  "git2",
  "homedir",
  "indicatif",
+ "lazy_static",
  "log",
  "paste",
  "rand",
@@ -908,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ filetime = "^0.2"
 flate2 = "1.0.28"
 homedir = "0.2.1"
 indicatif = "^0.17"
+lazy_static = "1.5.0"
 log = "^0.4"
 rand = "0.8.5"
 reqwest = { version = "^0.11", default-features = false, features = ["json", "blocking", "rustls-tls"] }

--- a/src/commands/package.rs
+++ b/src/commands/package.rs
@@ -7,7 +7,7 @@ use std::{
     process::{Command, Stdio},
 };
 
-use crate::execution::{setup_ctrlc_hook, Executor};
+use crate::execution::Executor;
 use crate::options::KerblamTomlOptions;
 use crate::options::Pipe;
 use crate::utils::{find_files, gzip_file, tar_files};
@@ -112,9 +112,8 @@ pub fn package_pipe(
             pipe_name
         )
     };
-    let sigint_rec = setup_ctrlc_hook().expect("Failed to setup SIGINT hook!");
     let backend: String = config.execution.backend.clone().into();
-    let base_container = executor.build_env(sigint_rec, &backend, false)?;
+    let base_container = executor.build_env(&backend, false)?;
     log::debug!("Base container name: {base_container:?}");
 
     // We now have the empty container. We can add our own layers.

--- a/src/commands/replay.rs
+++ b/src/commands/replay.rs
@@ -6,9 +6,7 @@ use std::process::{Command, Stdio};
 use anyhow::{bail, Result};
 use tempfile::TempDir;
 
-use crate::execution::{
-    generate_bind_mount_strings, run_protected_command, setup_ctrlc_hook, CommandResult,
-};
+use crate::execution::{generate_bind_mount_strings, run_protected_command, CommandResult};
 use crate::options::{ContainerBackend, KerblamTomlOptions};
 use crate::utils::gunzip_file;
 
@@ -112,10 +110,8 @@ pub fn replay(
             .expect("Cannot retrieve command output!")
     };
 
-    let signal_receiver = setup_ctrlc_hook()?;
-
     eprintln!("Replaying...");
-    let _return_value = match run_protected_command(builder, signal_receiver) {
+    let _return_value = match run_protected_command(builder) {
         Ok(CommandResult::Exited { res }) => Ok(Some(res)), // We don't care if it succeeded.
         Ok(CommandResult::Killed) => {
             eprintln!("\nChild process was killed.");


### PR DESCRIPTION
Plus, fixed a sneaky bug: if you back-to-back run your profiles, but delete the old profile from the toml, the cache looks for a non-existand profile path, and so you crash.
Now, we just ignore the missing profile with a warning.

## TODO
Before merging, tick all of these boxes:
- [X] `cargo test -- --include-ignored` passes without errors or warnings.
- [x] The [`CHANGELOG.md`](https://github.com/MrHedmad/kerblam/blob/main/CHANGELOG.md) has been updated to reflect these changes.
- [x] Documentation is updated that reflect these changes, or this PR changes nothing that is reflected in the docs.
- [x] @all-contributors is made aware of this PR, or I am already in the [all contributors list](https://github.com/MrHedmad/kerblam/blob/main/CONTRIBUTING.md#all-contributors).
